### PR TITLE
Add thread persistence to agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ node_modules/
 *.sqlite
 *.sqlite3
 *.db
+
+# SQLite database
+*.sqlite
+*.sqlite-journal

--- a/auto-content-creator/agents/package.json
+++ b/auto-content-creator/agents/package.json
@@ -20,7 +20,9 @@
     "dotenv": "^16.4.1",
     "express": "5.0.0",
     "winston": "^3.14.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "sqlite3": "^5.1.7",
+    "sqlite": "^5.1.1"
   },
   "devDependencies": {
     "@types/express": "5.0.0",

--- a/auto-content-creator/agents/src/index.ts
+++ b/auto-content-creator/agents/src/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import { writerRouter } from './routes/writer';
 import logger from './logger';
 import { config } from './config';
+import { initializeStorage } from './services/writerAgent';
 
 // Create an Express application
 const app = express();
@@ -28,7 +29,17 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   });
 });
 
-// Start server
-app.listen(port, () => {
-  logger.info(`Agents service is running on http://localhost:${port}`);
-});
+// Initialize storage before starting the server
+const startServer = async () => {
+  try {
+    await initializeStorage();
+    app.listen(port, () => {
+      logger.info(`Agents service is running on http://localhost:${port}`);
+    });
+  } catch (error) {
+    logger.error('Failed to start server:', error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/auto-content-creator/agents/src/routes/writer.ts
+++ b/auto-content-creator/agents/src/routes/writer.ts
@@ -65,4 +65,29 @@ router.post('/:threadId/feedback', (req, res, next) => {
     })();
 });
 
+// Add new endpoint to check thread state
+router.get('/:threadId/state', (req, res, next) => {
+    logger.info('Received request to get thread state:', req.params.threadId);
+    (async () => {
+        try {
+            const threadId = req.params.threadId;
+            const threadState = await writerAgent.getThreadState(threadId);
+
+            if (!threadState) {
+                return res.status(404).json({
+                    error: 'Thread not found'
+                });
+            }
+
+            res.json({
+                threadId,
+                lastOutput: threadState.lastOutput,
+            });
+        } catch (error) {
+            logger.error('Error getting thread state:', error);
+            next(error);
+        }
+    })();
+});
+
 export const writerRouter = router;

--- a/auto-content-creator/agents/src/services/threadStorage.ts
+++ b/auto-content-creator/agents/src/services/threadStorage.ts
@@ -1,0 +1,231 @@
+import sqlite3 from 'sqlite3';
+import { open, Database } from 'sqlite';
+import { ThreadState } from '../types';
+import logger from '../logger';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import path from 'path';
+
+// Database initialization
+const initializeDb = async (dbPath: string): Promise<Database> => {
+    logger.info('Initializing SQLite database at:', dbPath);
+    const db = await open({
+        filename: dbPath,
+        driver: sqlite3.Database
+    });
+
+    await db.exec(`
+        CREATE TABLE IF NOT EXISTS threads (
+            thread_id TEXT PRIMARY KEY,
+            state TEXT NOT NULL,
+            last_output TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+    `);
+
+    logger.info('Thread storage initialized with SQLite');
+    return db;
+};
+
+// Message deserialization
+const deserializeMessage = (msg: any) => {
+    try {
+        // Handle LangChain serialized format
+        if (msg.kwargs) {
+            const content = msg.kwargs.content;
+            return msg.id.includes('HumanMessage')
+                ? new HumanMessage({ content })
+                : new AIMessage({ content });
+        }
+
+        // Handle our simplified format
+        if (msg._type === 'human') {
+            return new HumanMessage({ content: msg.content });
+        }
+        return new AIMessage({ content: msg.content });
+    } catch (error) {
+        logger.error('Error deserializing message:', error);
+        return new AIMessage({ content: 'Error deserializing message' });
+    }
+};
+
+// Thread storage operations
+export const createThreadStorage = () => {
+    const dbPath = path.join(process.cwd(), 'thread-storage.sqlite');
+    let dbPromise = initializeDb(dbPath);
+
+    const ensureConnection = async (): Promise<Database> => {
+        const db = await dbPromise;
+        if (!db) {
+            throw new Error('Database connection not established');
+        }
+        return db;
+    };
+
+    const saveThread = async (threadId: string, state: ThreadState): Promise<void> => {
+        try {
+            const db = await ensureConnection();
+            logger.info(`Saving thread state for ${threadId}`, {
+                messageCount: state.state.messages?.length ?? 0,
+                hasLastOutput: !!state.lastOutput
+            });
+
+            // Ensure state has all required properties
+            const stateToSave = {
+                messages: state.state.messages ?? [],
+                reflectionScore: state.state.reflectionScore ?? 0,
+                researchPerformed: state.state.researchPerformed ?? false,
+                research: state.state.research ?? '',
+                reflections: state.state.reflections ?? [],
+                drafts: state.state.drafts ?? [],
+                feedbackHistory: state.state.feedbackHistory ?? [],
+            };
+
+            const serializedState = JSON.stringify(stateToSave, (key, value) => {
+                if (value instanceof HumanMessage || value instanceof AIMessage) {
+                    return {
+                        _type: value._getType(),
+                        content: value.content,
+                        additional_kwargs: value.additional_kwargs
+                    };
+                }
+                return value;
+            });
+
+            const serializedLastOutput = state.lastOutput ? JSON.stringify(state.lastOutput) : null;
+
+            await db.run(
+                `INSERT OR REPLACE INTO threads (thread_id, state, last_output, updated_at)
+                 VALUES (?, ?, ?, CURRENT_TIMESTAMP)`,
+                [threadId, serializedState, serializedLastOutput]
+            );
+
+            logger.info(`Thread state saved successfully: ${threadId}`);
+        } catch (error) {
+            logger.error(`Error saving thread ${threadId}:`, error);
+            throw error;
+        }
+    };
+
+    const loadThread = async (threadId: string): Promise<ThreadState | null> => {
+        try {
+            const db = await ensureConnection();
+            logger.info(`Loading thread state for ${threadId}`);
+
+            const row = await db.get(
+                'SELECT state, last_output FROM threads WHERE thread_id = ?',
+                threadId
+            );
+
+            if (!row) {
+                logger.warn(`Thread ${threadId} not found`);
+                return null;
+            }
+
+            const parsedState = JSON.parse(row.state);
+            const lastOutput = row.last_output ? JSON.parse(row.last_output) : undefined;
+
+            // Ensure messages array exists
+            if (!parsedState.messages) {
+                logger.warn(`Invalid state structure for thread ${threadId}: missing messages array`);
+                return null;
+            }
+
+            // Force messages into array if not already
+            const messageArray = Array.isArray(parsedState.messages)
+                ? parsedState.messages
+                : [parsedState.messages];
+
+            // Reconstruct message instances with improved error handling
+            const messages = messageArray.map((msg: any) => {
+                try {
+                    if (!msg) {
+                        logger.warn('Null or undefined message found');
+                        return new AIMessage({ content: 'Invalid message' });
+                    }
+                    return deserializeMessage(msg);
+                } catch (error) {
+                    logger.error('Error deserializing message:', { error, msg });
+                    return new AIMessage({ content: 'Error deserializing message' });
+                }
+            });
+
+            // Ensure all required state properties exist
+            const state = {
+                messages,
+                reflectionScore: parsedState.reflectionScore ?? 0,
+                researchPerformed: parsedState.researchPerformed ?? false,
+                research: parsedState.research ?? '',
+                reflections: parsedState.reflections ?? [],
+                drafts: parsedState.drafts ?? [],
+                feedbackHistory: parsedState.feedbackHistory ?? [],
+            };
+
+            logger.info(`Thread state loaded successfully: ${threadId}`, {
+                messageCount: messages.length,
+                hasLastOutput: !!lastOutput
+            });
+
+            return { state, lastOutput };
+        } catch (error) {
+            logger.error(`Error loading thread ${threadId}:`, error);
+            throw error;
+        }
+    };
+
+    const getAllThreads = async (): Promise<Array<{ threadId: string; createdAt: string; updatedAt: string }>> => {
+        try {
+            const db = await ensureConnection();
+            const rows = await db.all(
+                'SELECT thread_id, created_at, updated_at FROM threads ORDER BY updated_at DESC'
+            );
+
+            return rows.map(row => ({
+                threadId: row.thread_id,
+                createdAt: row.created_at,
+                updatedAt: row.updated_at
+            }));
+        } catch (error) {
+            logger.error('Error listing threads:', error);
+            throw error;
+        }
+    };
+
+    const deleteThread = async (threadId: string): Promise<void> => {
+        try {
+            const db = await ensureConnection();
+            await db.run('DELETE FROM threads WHERE thread_id = ?', threadId);
+            logger.info(`Thread deleted: ${threadId}`);
+        } catch (error) {
+            logger.error(`Error deleting thread ${threadId}:`, error);
+            throw error;
+        }
+    };
+
+    const cleanup = async (olderThanDays: number = 30): Promise<number> => {
+        try {
+            const db = await ensureConnection();
+            const result = await db.run(
+                'DELETE FROM threads WHERE updated_at < datetime("now", ?)',
+                [`-${olderThanDays} days`]
+            );
+
+            const deletedCount = result.changes || 0;
+            logger.info(`Cleaned up ${deletedCount} old threads`);
+            return deletedCount;
+        } catch (error) {
+            logger.error('Error during cleanup:', error);
+            throw error;
+        }
+    };
+
+    return {
+        saveThread,
+        loadThread,
+        getAllThreads,
+        deleteThread,
+        cleanup
+    };
+};
+
+export type ThreadStorage = ReturnType<typeof createThreadStorage>;

--- a/auto-content-creator/agents/src/types.ts
+++ b/auto-content-creator/agents/src/types.ts
@@ -1,3 +1,5 @@
+import { BaseMessage } from '@langchain/core/messages';
+
 export interface WriterAgentParams {
   category: string;
   topic: string;
@@ -15,4 +17,17 @@ export interface WriterAgentOutput {
   }>;
   drafts: string[];
   feedbackHistory?: string[];
+}
+
+export interface ThreadState {
+  state: {
+    messages: BaseMessage[];
+    reflectionScore: number;
+    researchPerformed: boolean;
+    research: string;
+    reflections: Array<{ critique: string; score: number }>;
+    drafts: string[];
+    feedbackHistory: string[];
+  };
+  lastOutput?: WriterAgentOutput;
 }


### PR DESCRIPTION
Closes #13 
This pull request introduces significant changes to the `auto-content-creator/agents` module, focusing on adding SQLite-based persistent storage for thread states and enhancing the writer agent's functionality. The main updates include integrating SQLite for thread storage, updating the server initialization process, and adding new endpoints for thread state management.

### Persistent Storage Integration:
* **`auto-content-creator/agents/package.json`**: Added `sqlite3` and `sqlite` dependencies for database operations.
* **`auto-content-creator/agents/src/services/threadStorage.ts`**: Implemented SQLite-based storage for thread states, including functions for saving, loading, and cleaning up thread data.
* **`auto-content-creator/agents/src/services/writerAgent.ts`**: Integrated the new thread storage system into the writer agent, replacing the in-memory storage with persistent storage. [[1]](diffhunk://#diff-a887a5025c7ac1435c722567762da6e673d1459393ee99cf97c11c45b05d1874R12) [[2]](diffhunk://#diff-a887a5025c7ac1435c722567762da6e673d1459393ee99cf97c11c45b05d1874L226-R254) [[3]](diffhunk://#diff-a887a5025c7ac1435c722567762da6e673d1459393ee99cf97c11c45b05d1874L259-L267) [[4]](diffhunk://#diff-a887a5025c7ac1435c722567762da6e673d1459393ee99cf97c11c45b05d1874L278-R342)

### Server Initialization:
* **`auto-content-creator/agents/src/index.ts`**: Updated the server initialization to ensure the storage is initialized before starting the server. [[1]](diffhunk://#diff-3979d1126a370fcc350793cf238e1db5f0f1b38ca519690738a163c99361b755R5) [[2]](diffhunk://#diff-3979d1126a370fcc350793cf238e1db5f0f1b38ca519690738a163c99361b755L31-R45)

### New Endpoints:
* **`auto-content-creator/agents/src/routes/writer.ts`**: Added a new endpoint to check the state of a specific thread.

### Type Definitions:
* **`auto-content-creator/agents/src/types.ts`**: Added new type definitions for `ThreadState` to support the new storage system. [[1]](diffhunk://#diff-380de9d62466a65dcfe58c79e3187954c7a660d52265c14528842b61807b607eR1-R2) [[2]](diffhunk://#diff-380de9d62466a65dcfe58c79e3187954c7a660d52265c14528842b61807b607eR21-R33)