### PR TITLE
Remove use of env and fix analytic id

### DIFF
--- a/auto-kol/agent-memory-viewer/frontend/src/components/Analytics.tsx
+++ b/auto-kol/agent-memory-viewer/frontend/src/components/Analytics.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
-const MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID
+const MEASUREMENT_ID = 'G-N5E7RC09G1'
 
 // Extend the Window interface to include dataLayer
 declare global {


### PR DESCRIPTION
## Remove use of env and fix analytic id

- I had made a typo in the GA ID
- No reason to have it as a env since it get expose on the client side anyway