### PR TITLE
fix a bug in batch processing - state management and type handling

### DIFF
--- a/auto-kol/agent/src/services/agents/nodes/autoApprovalNode.ts
+++ b/auto-kol/agent/src/services/agents/nodes/autoApprovalNode.ts
@@ -14,7 +14,7 @@ export const createAutoApprovalNode = (config: WorkflowConfig, scraper: Extended
         try {
             const lastMessage = state.messages[state.messages.length - 1];
             const parsedContent = parseMessageContent(lastMessage.content);
-            const { batchToFeedback } = parsedContent;
+            const { tweets, currentTweetIndex, batchToFeedback } = parsedContent;
 
             if (!batchToFeedback.length) {
                 logger.info('No pending responses found');
@@ -101,6 +101,8 @@ export const createAutoApprovalNode = (config: WorkflowConfig, scraper: Extended
             return {
                 messages: [new AIMessage({
                     content: JSON.stringify({
+                        tweets: tweets,
+                        currentTweetIndex: currentTweetIndex,
                         fromAutoApproval: true,
                         batchToRespond: processedResponses
                     })

--- a/auto-kol/agent/src/services/agents/nodes/engagementNode.ts
+++ b/auto-kol/agent/src/services/agents/nodes/engagementNode.ts
@@ -50,10 +50,10 @@ export const createEngagementNode = (config: WorkflowConfig) => {
             const lastMessage = state.messages[state.messages.length - 1];
             const parsedContent = parseMessageContent(lastMessage.content);
             const pendingEngagements = parsedContent.pendingEngagements || [];            
+            logger.info(`Current tweet index: ${parsedContent?.currentTweetIndex}`);
             
             if (pendingEngagements.length > 0) {
                 logger.info(`number of pending engagements: ${pendingEngagements.length}`);
-
                 return {
                     messages: [new AIMessage({
                         content: JSON.stringify({
@@ -61,7 +61,8 @@ export const createEngagementNode = (config: WorkflowConfig) => {
                             currentTweetIndex: parsedContent.currentTweetIndex,
                             batchToAnalyze: pendingEngagements,
                             pendingEngagements: [],
-                            lastProcessedId: parsedContent.lastProcessedId
+                            lastProcessedId: parsedContent.lastProcessedId,
+                            batchProcessing: true
                         })
                     })],
                     processedTweets: state.processedTweets
@@ -70,7 +71,8 @@ export const createEngagementNode = (config: WorkflowConfig) => {
 
             const BATCH_SIZE = globalConfig.ENGAGEMENT_BATCH_SIZE;
             const startIdx = parsedContent.currentTweetIndex || 0;
-            const endIdx = Math.min(startIdx + BATCH_SIZE, parsedContent.tweets.length);
+            const proposedEndIdx = Number(startIdx) + Number(BATCH_SIZE);
+            const endIdx = Math.min(proposedEndIdx, parsedContent.tweets.length);
             const batchTweets = parsedContent.tweets.slice(startIdx, endIdx);
 
             logger.info('Processing batch of tweets', {
@@ -116,9 +118,10 @@ export const createEngagementNode = (config: WorkflowConfig) => {
                 messages: [new AIMessage({
                     content: JSON.stringify({
                         tweets: parsedContent.tweets,
-                        currentTweetIndex: tweetsToEngage.length > 0 ? startIdx : endIdx,
+                        currentTweetIndex: endIdx,
                         pendingEngagements: tweetsToEngage,
-                        lastProcessedId: parsedContent.lastProcessedId
+                        lastProcessedId: parsedContent.lastProcessedId,
+                        batchProcessing: true,
                     })
                 })],
                 processedTweets: newProcessedTweets


### PR DESCRIPTION
There was a bug in how we were handling batch processing.
1. `parsedContent` is JSON and we have to parse it to Number to correctly handle the cursor on indexes when processing the second batch to end. 
2. autoApprovalNode must return the `currentTweetIndex` as well as `tweets` to complete the workflow.

p.s. I highly suggest to move the unnecessary variables like `currentTweetIndex` to out of scope of `messages`.  I'll fix and open a seperate PR for this.

I tested multiple times with more than 100 tweets for processing, it did well and didn't hit the recursion limit. 