### PR TITLE
fix auto_drive typo in config.example.yaml

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -10,7 +10,7 @@ twitter:
   POST_INTERVAL_MINUTES: 90
   POST_TWEETS: false
 
-autodrive:
+auto_drive:
   upload: false
 
 llm:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -78,7 +78,7 @@ export const config = (() => {
       autoDriveConfig: {
         AUTO_DRIVE_API_KEY: process.env.AUTO_DRIVE_API_KEY,
         AUTO_DRIVE_ENCRYPTION_PASSWORD: process.env.AUTO_DRIVE_ENCRYPTION_PASSWORD,
-        AUTO_DRIVE_UPLOAD: yamlConfig.auto_drive?.upload ?? false,
+        AUTO_DRIVE_UPLOAD: yamlConfig.auto_drive.upload ?? false,
       },
       blockchainConfig: {
         RPC_URL: process.env.RPC_URL || undefined,


### PR DESCRIPTION
We will want to add some better checking around config values.