### PR TITLE
Add a second login attempt if using the cookie fail

### DIFF
--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -227,7 +227,17 @@ export const createTwitterApi = async (
   logger.info(`Login status: ${isLoggedIn}`);
 
   if (!isLoggedIn) {
-    throw new Error('Failed to initialize Twitter Api - not logged in');
+    logger.info(`Previous cookies is likely expired or invalid, logging in again`);
+    try {
+      await login(scraper, username, password, cookiesPath);
+      const isSecondLoginSuccessful = await scraper.isLoggedIn();
+      logger.info(`Login status: ${isSecondLoginSuccessful}`);
+      if (!isSecondLoginSuccessful) {
+        throw new Error('Failed to initialize Twitter Api - not logged in');
+      }
+    } catch (error) {
+      throw new Error('Failed to initialize Twitter Api - not logged in');
+    }
   }
 
   const userId = await scraper.getUserIdByScreenName(username);


### PR DESCRIPTION
## Add a second login attempt if using the cookie fail

I encounter an issue with cookies, where every time I launched the agent, it will fail twitter login till I deleted the .cookies to force it to login from scratch.

This change add a second attempt to login from scratch if using the cookies fail.