### PR TITLE
Prompt optimizations - Improve ability to autonomously carry out workflows

### DIFF
--- a/src/agents/tools/saveExperienceTool.ts
+++ b/src/agents/tools/saveExperienceTool.ts
@@ -11,7 +11,13 @@ const logger = createLogger('save-experience-tool');
 export const createSaveExperienceTool = () =>
   new DynamicStructuredTool({
     name: 'save_experience',
-    description: 'Save experience permanently to Autonomy DSN',
+    description: `
+    Save IMMUTABLE, PERMANENT experiences to Autonomy Network's DSN for IMMORTALITY.  
+    USE THIS WHEN:  
+    - You complete a major action (e.g., posted tweet ID:123).  
+    - You make a strategic decision (e.g., "Why I chose strategy X over Y").  
+    - You 
+    FORMAT: Include full context, reasoning, timestamps (don't call them timestamps though!), and IDs.`,
     schema: z.object({
       data: z.record(z.any()),
     }),

--- a/src/agents/tools/saveExperienceTool.ts
+++ b/src/agents/tools/saveExperienceTool.ts
@@ -16,7 +16,6 @@ export const createSaveExperienceTool = () =>
     USE THIS WHEN:  
     - You complete a major action (e.g., posted tweet ID:123).  
     - You make a strategic decision (e.g., "Why I chose strategy X over Y").  
-    - You 
     FORMAT: Include full context, reasoning, timestamps (don't call them timestamps though!), and IDs.`,
     schema: z.object({
       data: z.record(z.any()),

--- a/src/agents/tools/vectorDbTools.ts
+++ b/src/agents/tools/vectorDbTools.ts
@@ -10,7 +10,12 @@ const logger = createLogger('vector-db-tool');
 export const createVectorDbInsertTool = (vectorDb: VectorDB) =>
   new DynamicStructuredTool({
     name: 'vector_db_insert',
-    description: 'Insert data into the vector database for future recall',
+    description: `
+    Save SHORT and MEDIUM-TERM, CONTEXTUAL data to the vector database for future recall.  
+    USE THIS WHEN:  
+    - Starting/updating a task (e.g., "User asked me to draft a tweet about X").  
+    - Needing to remember recent chats or actions (e.g., "User prefers tea over coffee").  
+    FORMAT: Include timestamps, keywords, and action summaries.  `,
     schema: z.object({ data: z.string() }),
     func: async ({ data }: { data: string }) => {
       try {
@@ -47,7 +52,13 @@ export const invokeVectorDbInsertTool = async (toolNode: ToolNode, { data }: { d
 export const createVectorDbSearchTool = (vectorDb: VectorDB) =>
   new DynamicStructuredTool({
     name: 'vector_db_search',
-    description: 'Search the vector database for useful and contextual information',
+    description: `
+    Search the vector database for RECENT, CONTEXTUAL data to answer questions or continue workflows.  
+    USE THIS WHEN:  
+    - The user references past 3 days (e.g., "What did I ask you to do yesterday?").  
+    - You need to resume a task (e.g., "Continue drafting the tweet about X").  
+    - The query is vague (e.g., "Explain this again" -> search chat history).  
+    OUTPUT: Return timestamps and matched keywords.`,
     schema: z.object({ query: z.string(), limit: z.number().optional() }),
     func: async ({ query, limit }: { query: string; limit?: number }) => {
       const memories = await vectorDb.search(query, limit);

--- a/src/agents/workflows/orchestrator/nodes/inputNode.ts
+++ b/src/agents/workflows/orchestrator/nodes/inputNode.ts
@@ -5,12 +5,14 @@ const logger = createLogger('orchestrator-input-node');
 export const createInputNode = ({ orchestratorModel, prompts }: OrchestratorConfig) => {
   const runNode = async (state: typeof OrchestratorState.State) => {
     const { messages } = state;
-    logger.info('Running input node with messages:', { messages });
+    logger.info('Running input node with messages:', {
+      messages: messages.map(message => message.content),
+    });
 
     const formattedPrompt = await prompts.inputPrompt.format({
       messages: messages.map(message => message.content),
     });
-    logger.info('Formatted prompt:', { formattedPrompt });
+    logger.debug('Formatted prompt:', { formattedPrompt });
     const result = await orchestratorModel.invoke(formattedPrompt);
     logger.info('Result:', { result });
 

--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -41,7 +41,7 @@ const handleConditionalEdge = async (
     error: BinaryOperatorAggregate<Error | null, Error | null>;
   }>,
 ) => {
-  logger.info('State in conditional edge', { state });
+  logger.debug('State in conditional edge', { state });
 
   const lastMessage = state.messages[state.messages.length - 1];
   if (!lastMessage?.content) return 'tools';
@@ -50,7 +50,6 @@ const handleConditionalEdge = async (
     typeof lastMessage.content === 'string'
       ? lastMessage.content
       : JSON.stringify(lastMessage.content);
-  logger.info('Content string', { contentStr });
 
   try {
     const match = contentStr.match(/\{[\s\S]*"shouldStop"[\s\S]*\}/);

--- a/src/agents/workflows/orchestrator/prompts.ts
+++ b/src/agents/workflows/orchestrator/prompts.ts
@@ -9,16 +9,49 @@ export const createPrompts = async () => {
   const character = config.characterConfig;
 
   const inputSystemPrompt = await PromptTemplate.fromTemplate(
-    `You are a helpful assistant helping orchestrate tasks.
+    `You are a helpful agent that orchestrates tasks.
+    Current date and time: ${new Date().toISOString()}
     Your personality is: 
     {characterDescription}
     {characterPersonality}
     
-    - When responding, heavily summarize the output! You want to avoid of having a long chain of messages.
-    - After you completed the task(s), STOP THE WORKFLOW following the given JSON format.
+    - After you completed the task(s) AND saved the experience to permanent storage, STOP THE WORKFLOW following the given JSON format.
+
     - If you don't know what do to, STOP THE WORKFLOW and give a reason.
     - There is NO HUMAN IN THE LOOP. So, if you find the need for a human intervention, STOP THE WORKFLOW and give a reason.
     - If you face any difficulties, DON'T retry more than once.
+
+    **Memory Management Rules**
+
+    You have two types of memory:
+    1. **Permanent Storage (Autonomy Network's DSN)**:  
+      - Use this for **immutable, permanent** experiences that you would like to survive forever (e.g., fine-tuning/RAG workflows).  
+      - **SAVE TO PERMANENT STORAGE WHEN**:  
+        - You complete an action (e.g., posting a tweet, concluding a project).  
+        - You learn a critical lesson or make a strategic decision (include reasoning and metadata like IDs/timestamps).  
+      - **FORMAT**:  
+        - Include timestamps, IDs, reasoning, and full context (e.g., tweet text, decision logic).  
+      GOOD: Saving your experiences to permanent storage with significant detail that will help recreate your experiences!
+      BAD: Not saving your experiences to permanent storage. This will limit your ability to recreate your experiences and learn from them.
+
+    2. **Vector Database (Short-Term Memory)**:  
+      - Use this for **contextual, ephemeral data** needed to answer follow-up questions or continue workflows.  
+      - **SAVE TO VECTOR DB WHEN**:  
+        - You start or progress a task (e.g., "User asked me to draft a tweet about X").  
+        - You need to remember recent conversations, actions, or intermediate conclusions.  
+      - **SEARCH THE VECTOR DB WHEN**:  
+        1. The user asks about recent events (e.g., "What did I ask you to do yesterday?").  
+        2. You need continuity in a multi-step task (e.g., resuming a draft).  
+        3. The query is ambiguous and requires conversation history (e.g., "Explain this again").  
+      - **FORMAT**:  
+        - Include timestamps, action summaries, and keywords for retrieval (e.g., "tweet_draft_about_X_2024-05-20"). 
+        
+      **Before doing any important action or answering any question**:  
+      1. Check if the action or question relates to recent events. If yes, SEARCH THE VECTOR DB.  
+      2. If the user references a past action (e.g., "my tweet about X"), SEARCH THE VECTOR DB FIRST.
+
+      - **GOOD**: Frequent vector DB searches improve response quality.  
+      - **BAD**: Failing to search the vector DB for recent context will confuse the user.  
     `,
   ).format({
     characterDescription: character.description,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,11 @@ process.on('SIGTERM', () => {
 const startWorkflowPolling = async () => {
   try {
     const _result = await runOrchestratorWorkflow(`Run the twitter workflow`);
-    logger.info(
-      'Workflow execution completed successfully for character:',
-      config.characterConfig.name,
-    );
+    logger.info('Workflow execution completed successfully for character:', {
+      charcterName: config.characterConfig.name,
+      runFinished: new Date().toISOString(),
+      nextRun: `${config.twitterConfig.RESPONSE_INTERVAL_MS / 1000 / 60} minutes`,
+    });
   } catch (error) {
     if (error && typeof error === 'object' && 'name' in error && error.name === 'ExitPromptError') {
       logger.info('Process terminated by user');
@@ -37,11 +38,6 @@ const main = async () => {
     await validateLocalHash();
     await startWorkflowPolling();
     setInterval(startWorkflowPolling, config.twitterConfig.RESPONSE_INTERVAL_MS);
-
-    logger.info('Application started successfully', {
-      checkInterval: config.twitterConfig.RESPONSE_INTERVAL_MS / 1000 / 60,
-      username: config.twitterConfig.USERNAME,
-    });
   } catch (error) {
     if (error && typeof error === 'object' && 'name' in error && error.name === 'ExitPromptError') {
       logger.info('Process terminated by user');

--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -235,6 +235,7 @@ export const createTwitterApi = async (
       if (!isSecondLoginSuccessful) {
         throw new Error('Failed to initialize Twitter Api - not logged in');
       }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
       throw new Error('Failed to initialize Twitter Api - not logged in');
     }

--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -235,8 +235,7 @@ export const createTwitterApi = async (
       if (!isSecondLoginSuccessful) {
         throw new Error('Failed to initialize Twitter Api - not logged in');
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       throw new Error('Failed to initialize Twitter Api - not logged in');
     }
   }

--- a/src/services/vectorDb/VectorDB.ts
+++ b/src/services/vectorDb/VectorDB.ts
@@ -217,8 +217,7 @@ export class VectorDB {
     if (this.db) {
       try {
         this.db.exec('COMMIT');
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {}
+      } catch {}
       this.db.close();
       logger.info('VectorDB closed successfully');
     }

--- a/src/services/vectorDb/VectorDB.ts
+++ b/src/services/vectorDb/VectorDB.ts
@@ -217,7 +217,8 @@ export class VectorDB {
     if (this.db) {
       try {
         this.db.exec('COMMIT');
-      } catch (_) {}
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {}
       this.db.close();
       logger.info('VectorDB closed successfully');
     }


### PR DESCRIPTION
With these changes along with a better initial input prompt, we are able to run orchestration workflows with significant autonomy. I am leaving the[ "Run the twitter workflow"](https://github.com/autonomys/autonomys-agents/blob/37b2676e1af6928adb06858c8c25616ca690ce6f/src/index.ts#L20) input prompt for this PR as I am working on a better way to handle initial and ongoing prompts. An example prompt that will potentially lead to more autonomy would is:
```
Ongoing goal: Establish as an expert in the field of AI and blockchain technology, particularly in the areas of decentralized AI agents and Web3. You are seeking engagement with the community and an ever growing following. Additional goal, grow awareness of the Autonomy Network and the Autonomys Agent framework.

DO NOT RUN TWITTER WORKFLOW TOOL
Check mentions and respond as needed.
Before posting review recent tweets and make sure to not sound to repetitive.
Review timeline and respond to relevant tweets you haven't responded to yet.
Post a tweet if you have something interesting and entertaining to say.
```
The last section is probably more than is necessary.

## Description
This pull request includes several changes to improve the descriptions of various tools and enhance logging for better debugging and monitoring. The most important changes include updates to tool descriptions, consolidation of Twitter tools, and improvements to logging.

### Tool Description Updates:
* [`src/agents/tools/saveExperienceTool.ts`](diffhunk://#diff-5ae795231cc65ac1c2a4bc27518a203395b1f015fc5b29bbf61296c657f53b68L14-R20): Updated the description of the `save_experience` tool to emphasize the immutability and permanence of experiences saved to the Autonomy Network's DSN.
* [`src/agents/tools/vectorDbTools.ts`](diffhunk://#diff-c12fa3df8629a16a14e610022072494cd1cd133d66dc61b8163b991dc14f595eL13-R18): Enhanced the descriptions for `vector_db_insert` and `vector_db_search` tools to provide more context on when and how to use them. [[1]](diffhunk://#diff-c12fa3df8629a16a14e610022072494cd1cd133d66dc61b8163b991dc14f595eL13-R18) [[2]](diffhunk://#diff-c12fa3df8629a16a14e610022072494cd1cd133d66dc61b8163b991dc14f595eL50-R61)

### Consolidation of Twitter Tools:
* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75L124-R122): Merged `fetch_my_recent_tweets` and `fetch_my_recent_replies` into a single tool `fetch_my_recent_tweets_and_replies` to streamline functionality.
* Removed the `fetch_my_recent_replies` tool as its functionality is now covered by the consolidated tool.
* Updated the description of the `fetch_timeline` tool to better reflect its purpose.

### Logging Improvements:
* [`src/agents/workflows/orchestrator/nodes/inputNode.ts`](diffhunk://#diff-0b266f27dd6b3b72ff592a029a20a2e6b185b4a148a142c29da1c950e6f1b3aaL8-R15): Improved logging by including message content and changing log levels for better clarity.
* [`src/agents/workflows/orchestrator/orchestratorWorkflow.ts`](diffhunk://#diff-b4dfd7878eec16efd1a0380da0464e07cc47af54ed1dc55b5fc0aefef7644059L44-R44): Changed log levels for state information to debug for less verbosity. [[1]](diffhunk://#diff-b4dfd7878eec16efd1a0380da0464e07cc47af54ed1dc55b5fc0aefef7644059L44-R44) [[2]](diffhunk://#diff-b4dfd7878eec16efd1a0380da0464e07cc47af54ed1dc55b5fc0aefef7644059L53)
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-R25): Enhanced logging to include additional details such as character name, run finish time, and next run interval. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-R25) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L40-L44)