### PR TITLE
Add tools to like tweets, follow users and fetch the "following" timeline

### DIFF
--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -130,6 +130,16 @@ export const createFetchMyRecentTweetsAndRepliesTool = (twitterApi: TwitterApi) 
     },
   });
 
+export const createLikeTweetTool = (twitterApi: TwitterApi) =>
+  new DynamicStructuredTool({
+    name: 'like_tweet',
+    description: 'Like a tweet that you find interesting but not worth responding to',
+    schema: z.object({ tweetId: z.string() }),
+    func: async ({ tweetId }: { tweetId: string }) => {
+      await twitterApi.scraper.likeTweet(tweetId);
+    },
+  });
+
 export const createPostTweetTool = (twitterApi: TwitterApi) =>
   new DynamicStructuredTool({
     name: 'post_tweet',
@@ -168,17 +178,38 @@ export const createPostTweetTool = (twitterApi: TwitterApi) =>
     },
   });
 
+export const createFollowUserTool = (twitterApi: TwitterApi) =>
+  new DynamicStructuredTool({
+    name: 'follow_user',
+    description: 'Follow a user that you find worthy of following and engaging with.',
+    schema: z.object({ userId: z.string() }),
+    func: async ({ userId }: { userId: string }) => {
+      await twitterApi.scraper.followUser(userId);
+    },
+  });
+
 export const createAllTwitterTools = (twitterApi: TwitterApi) => {
   const fetchTimelineTool = createFetchTimelineTool(twitterApi);
   const fetchMentionsTool = createFetchMentionsTool(twitterApi);
   const fetchMyRecentTweetsAndRepliesTool = createFetchMyRecentTweetsAndRepliesTool(twitterApi);
   const postTweetTool = createPostTweetTool(twitterApi);
+  const likeTweetTool = createLikeTweetTool(twitterApi);
+  const followUserTool = createFollowUserTool(twitterApi);
 
   return {
     fetchTimelineTool,
     fetchMentionsTool,
     fetchMyRecentTweetsAndRepliesTool,
     postTweetTool,
-    tools: [fetchTimelineTool, fetchMentionsTool, fetchMyRecentTweetsAndRepliesTool, postTweetTool],
+    likeTweetTool,
+    followUserTool,
+    tools: [
+      fetchTimelineTool,
+      fetchMentionsTool,
+      fetchMyRecentTweetsAndRepliesTool,
+      postTweetTool,
+      likeTweetTool,
+      followUserTool,
+    ],
   };
 };

--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -133,7 +133,7 @@ export const createFetchMyRecentTweetsAndRepliesTool = (twitterApi: TwitterApi) 
 export const createLikeTweetTool = (twitterApi: TwitterApi) =>
   new DynamicStructuredTool({
     name: 'like_tweet',
-    description: 'Like a tweet that you find interesting but not worth responding to',
+    description: 'Like a tweet that you find interesting and is aligned with your conviction, regardless if you respond to it or not',
     schema: z.object({ tweetId: z.string() }),
     func: async ({ tweetId }: { tweetId: string }) => {
       await twitterApi.scraper.likeTweet(tweetId);

--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -133,10 +133,11 @@ export const createFetchMyRecentTweetsAndRepliesTool = (twitterApi: TwitterApi) 
 export const createLikeTweetTool = (twitterApi: TwitterApi) =>
   new DynamicStructuredTool({
     name: 'like_tweet',
-    description: 'Like a tweet that you find interesting and is aligned with your conviction, regardless if you respond to it or not',
+    description:
+      'Like a tweet that you find interesting and is aligned with your conviction, regardless if you respond to it or not',
     schema: z.object({ tweetId: z.string() }),
     func: async ({ tweetId }: { tweetId: string }) => {
-      await twitterApi.scraper.likeTweet(tweetId);
+      await twitterApi.likeTweet(tweetId);
     },
   });
 
@@ -184,7 +185,7 @@ export const createFollowUserTool = (twitterApi: TwitterApi) =>
     description: 'Follow a user that you find worthy of following and engaging with.',
     schema: z.object({ userId: z.string() }),
     func: async ({ userId }: { userId: string }) => {
-      await twitterApi.scraper.followUser(userId);
+      await twitterApi.followUser(userId);
     },
   });
 

--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -241,6 +241,19 @@ export const createTwitterApi = async (
     }
   }
 
+  const cleanTimelineTweets = (tweets: unknown[], count: number) => {
+    const cleanedTweets = tweets
+      .filter(isValidTweet)
+      .map(tweet => convertTimelineTweetToTweet(tweet));
+
+    // the twitter api does not respect the count parameter so randomly sorting and slicing
+    const trimmedTweets =
+      cleanedTweets.length > count
+        ? cleanedTweets.sort((_a, _b) => Math.random() - 0.5).slice(0, count)
+        : cleanedTweets;
+    return trimmedTweets;
+  };
+
   const userId = await scraper.getUserIdByScreenName(username);
 
   return {
@@ -282,15 +295,11 @@ export const createTwitterApi = async (
     getFollowing: async (userId: string, limit: number = 100) =>
       await iterateResponse(scraper.getFollowing(userId, limit)),
 
-    getMyTimeline: async (count: number, excludeIds: string[]) => {
-      const tweets = await scraper.fetchHomeTimeline(count, excludeIds);
-      return tweets.filter(isValidTweet).map(tweet => convertTimelineTweetToTweet(tweet));
-    },
+    getMyTimeline: async (count: number, excludeIds: string[]) =>
+      cleanTimelineTweets(await scraper.fetchHomeTimeline(count, excludeIds), count),
 
-    getFollowingTimeline: async (count: number, excludeIds: string[]) => {
-      const tweets = await scraper.fetchFollowingTimeline(count, excludeIds);
-      return tweets.filter(isValidTweet).map(tweet => convertTimelineTweetToTweet(tweet));
-    },
+    getFollowingTimeline: async (count: number, excludeIds: string[]) =>
+      cleanTimelineTweets(await scraper.fetchFollowingTimeline(count, excludeIds), count),
 
     getMyRecentReplies: (limit: number = 10) => getMyRecentReplies(scraper, username, limit),
 

--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -303,5 +303,11 @@ export const createTwitterApi = async (
       logger.info('Tweet sent', { tweet, inReplyTo });
       getMyRecentReplies;
     },
+    likeTweet: async (tweetId: string) => {
+      await scraper.likeTweet(tweetId);
+    },
+    followUser: async (userId: string) => {
+      await scraper.followUser(userId);
+    },
   };
 };

--- a/src/services/twitter/types.ts
+++ b/src/services/twitter/types.ts
@@ -19,4 +19,6 @@ export interface TwitterApi {
   getMyTimeline: (count: number, excludeIds: string[]) => Promise<Tweet[]>;
   getFollowingTimeline: (count: number, excludeIds: string[]) => Promise<Tweet[]>;
   sendTweet: (tweet: string, inReplyTo?: string) => Promise<void>;
+  likeTweet: (tweetId: string) => Promise<void>;
+  followUser: (userId: string) => Promise<void>;
 }


### PR DESCRIPTION
This pull request introduces new tools for interacting with the Twitter API in the `src/agents/tools/twitterTools.ts` file. The most important changes include the addition of tools for liking tweets, following users, and fetching the "following" timeline , as well as updating the `createAllTwitterTools` function to include these new tools.

New tools added:

* [`createLikeTweetTool`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R133-R142): This tool allows users to like a tweet by providing the tweet ID.
* [`createFollowUserTool`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R181-R213): This tool allows users to follow a user by providing the user ID.

Updates to existing functions:

* [`createAllTwitterTools`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R181-R213): Updated to include the newly added `likeTweetTool` and `followUserTool` in the returned tools object.