### PR TITLE
Return useful info from twitter workflow instead of final state

### DIFF
--- a/src/agents/workflows/twitter/twitterWorkflow.ts
+++ b/src/agents/workflows/twitter/twitterWorkflow.ts
@@ -183,7 +183,7 @@ const createWorkflowRunner = async (): Promise<WorkflowRunner> => {
       }
 
       logger.info('Workflow completed', { threadId });
-      return finalState;
+      return { completionTime: new Date().toISOString(), completionSuccess: true };
     },
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ process.on('SIGTERM', () => {
 
 const startWorkflowPolling = async () => {
   try {
-    const _result = await runOrchestratorWorkflow(`Run the twitter workflow`);
+    const _result = await runOrchestratorWorkflow(
+      `You are expected to run the twitter workflow periodically in order to maintain social engagement. The current date and time is ${new Date().toISOString()}`,
+    );
+
     logger.info('Workflow execution completed successfully for character:', {
       charcterName: config.characterConfig.name,
       runFinished: new Date().toISOString(),


### PR DESCRIPTION
The twitter workflow was returning `finalState` at the end of the workflow, which wasn't useful information to the orchestrator creating humorous but frustrating refusals to execute the twitter workflow. Additionally, the input prompt now includes the time of execution in order to let the orchestrator know it is a new request. This is temporary, as the future process will not be driven by polling the same input prompt ever N minutes.