### PR TITLE
Add fetchFollowing and fetchProfile tools

### DIFF
--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -142,6 +142,28 @@ export const createFetchMyRecentTweetsAndRepliesTool = (twitterApi: TwitterApi) 
     },
   });
 
+export const createFetchFollowingTool = (twitterApi: TwitterApi) =>
+  new DynamicStructuredTool({
+    name: 'fetch_following',
+    description: 'Fetch the following of a given Twitter user',
+    schema: z.object({ username: z.string(), numFollowing: z.number() }),
+    func: async ({ username, numFollowing }: { username: string; numFollowing: number }) => {
+      const following = await twitterApi.getFollowing(username, numFollowing);
+      return { following };
+    },
+  });
+
+export const createFetchProfileTool = (twitterApi: TwitterApi) =>
+  new DynamicStructuredTool({
+    name: 'fetch_profile',
+    description: 'Fetch the profile of a given Twitter user',
+    schema: z.object({ username: z.string() }),
+    func: async ({ username }: { username: string }) => {
+      const profile = await twitterApi.getProfile(username);
+      return { profile };
+    },
+  });
+
 export const createLikeTweetTool = (twitterApi: TwitterApi) =>
   new DynamicStructuredTool({
     name: 'like_tweet',
@@ -209,12 +231,16 @@ export const createAllTwitterTools = (twitterApi: TwitterApi) => {
   const postTweetTool = createPostTweetTool(twitterApi);
   const likeTweetTool = createLikeTweetTool(twitterApi);
   const followUserTool = createFollowUserTool(twitterApi);
+  const fetchProfileTool = createFetchProfileTool(twitterApi);
+  const fetchFollowingTool = createFetchFollowingTool(twitterApi);
 
   return {
     fetchTimelineTool,
     fetchFollowingTimelineTool,
     fetchMentionsTool,
     fetchMyRecentTweetsAndRepliesTool,
+    fetchProfileTool,
+    fetchFollowingTool,
     postTweetTool,
     likeTweetTool,
     followUserTool,
@@ -223,6 +249,8 @@ export const createAllTwitterTools = (twitterApi: TwitterApi) => {
       fetchFollowingTimelineTool,
       fetchMentionsTool,
       fetchMyRecentTweetsAndRepliesTool,
+      fetchProfileTool,
+      fetchFollowingTool,
       postTweetTool,
       likeTweetTool,
       followUserTool,

--- a/src/services/twitter/client.ts
+++ b/src/services/twitter/client.ts
@@ -291,8 +291,10 @@ export const createTwitterApi = async (
 
     getMyRepliedToIds: async () => Array.from(await getUserReplyIds(scraper, username, 100)),
 
-    getFollowing: async (userId: string, limit: number = 100) =>
-      await iterateResponse(scraper.getFollowing(userId, limit)),
+    getFollowing: async (username: string, limit: number = 100) => {
+      const userId = await scraper.getUserIdByScreenName(username);
+      return await iterateResponse(scraper.getFollowing(userId, limit));
+    },
 
     getMyTimeline: async (count: number, excludeIds: string[]) =>
       cleanTimelineTweets(await scraper.fetchHomeTimeline(count, excludeIds), count),


### PR DESCRIPTION
This pull request introduces new tools for fetching Twitter user profiles and their following list, and updates existing functionality to support these new tools. The most important changes include adding new tools to the `twitterTools` module and updating the `twitterApi` service to fetch user IDs by username.

New tools added:

* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R145-R166): Added `createFetchFollowingTool` to fetch the following list of a given Twitter user.
* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R145-R166): Added `createFetchProfileTool` to fetch the profile of a given Twitter user.

Updates to existing functionality:

* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R234-R243): Included `fetchProfileTool` and `fetchFollowingTool` in the `createAllTwitterTools` function to make these tools available for use. [[1]](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R234-R243) [[2]](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75R252-R253)
* [`src/services/twitter/client.ts`](diffhunk://#diff-9630eb2796eecdfade33ba5ad88277b7d43c3d8f2d1bd32765da2ba202133addL294-R297): Modified `getFollowing` method to fetch user ID by username before retrieving the following list.