### PR TITLE
Add tool for retrieving current time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "autonomys-agents",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Autonomys Agents",
     "main": "dist/index.js",
     "type": "module",

--- a/src/agents/tools/getTimeTool.ts
+++ b/src/agents/tools/getTimeTool.ts
@@ -1,0 +1,12 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+export const createGetCurrentTimeTool = () =>
+  new DynamicStructuredTool({
+    name: 'get_current_time',
+    description:
+      'Returns the current real-world time. Use this whenever you need to know the current time, make scheduling decisions, or calculate time differences. The time is returned in ISO format. This is the only way to get accurate current time information.',
+    schema: z.object({}),
+    func: async () => {
+      return new Date().toISOString();
+    },
+  });

--- a/src/agents/workflows/orchestrator/tools.ts
+++ b/src/agents/workflows/orchestrator/tools.ts
@@ -4,13 +4,14 @@ import { createVectorDbInsertTool, createVectorDbSearchTool } from '../../tools/
 import { TwitterApi } from '../../../services/twitter/types.js';
 import { VectorDB } from '../../../services/vectorDb/VectorDB.js';
 import { createSaveExperienceTool } from '../../tools/saveExperienceTool.js';
-
+import { createGetCurrentTimeTool } from '../../tools/getTimeTool.js';
 export const createTools = (twitterApi: TwitterApi, vectorDb: VectorDB) => {
   const twitterWorkflowTool = createTwitterWorkflowTool();
   const twitterTools = createAllTwitterTools(twitterApi);
   const vectorDbSearchTool = createVectorDbSearchTool(vectorDb);
   const vectorDbInsertTool = createVectorDbInsertTool(vectorDb);
   const saveExperienceTool = createSaveExperienceTool();
+  const getCurrentTimeTool = createGetCurrentTimeTool();
 
   return {
     ...twitterTools,
@@ -18,12 +19,14 @@ export const createTools = (twitterApi: TwitterApi, vectorDb: VectorDB) => {
     vectorDbSearchTool,
     vectorDbInsertTool,
     saveExperienceTool,
+    getCurrentTimeTool,
     tools: [
       ...twitterTools.tools,
       twitterWorkflowTool,
       vectorDbSearchTool,
       vectorDbInsertTool,
       saveExperienceTool,
+      getCurrentTimeTool,
     ],
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ process.on('SIGTERM', () => {
 const startWorkflowPolling = async () => {
   try {
     const _result = await runOrchestratorWorkflow(
-      `You are expected to run the twitter workflow periodically in order to maintain social engagement. The current date and time is ${new Date().toISOString()}`,
+      `You are expected to run the twitter workflow periodically in order to maintain social engagement.`,
     );
 
     logger.info('Workflow execution completed successfully for character:', {


### PR DESCRIPTION
This pull request includes several changes to the `autonomys-agents` project, focusing on adding a new tool for getting the current time, updating dependencies, and improving workflow execution.

### New Features:

* [`src/agents/tools/getTimeTool.ts`](diffhunk://#diff-df931fed9abe73b6131ddcb8e9b8c898ac30818510adf289c7b6c265e8ab08c2R1-R12): Introduced a new `createGetCurrentTimeTool` function that returns the current time in ISO format using the `DynamicStructuredTool` from `@langchain/core/tools` and `zod` for schema validation.
* [`src/agents/workflows/orchestrator/tools.ts`](diffhunk://#diff-55b82f5fb1f170f81a7e10c667ea1ad850222cc4534cafb9784a12b4781e9a49L7-R29): Added the `createGetCurrentTimeTool` to the list of tools in the orchestrator workflow.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `0.2.0` to `0.2.1`.

### Workflow Improvements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L21-R21): Removed the inclusion of the current date and time in the message for running the Twitter workflow periodically.