### PR TITLE
Refactor orchestrator workflow to be instantiable with tools and prompts

### DIFF
--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -10,28 +10,28 @@ import { createLogger } from '../../../utils/logger.js';
 import { LLMFactory } from '../../../services/llm/factory.js';
 import { config } from '../../../config/index.js';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
-import { createTools } from './tools.js';
 import { createNodes } from './nodes.js';
-import { OrchestratorConfig, OrchestratorInput, OrchestratorState } from './types.js';
-import { createPrompts } from './prompts.js';
-import { BaseMessage, HumanMessage } from '@langchain/core/messages';
-import { createTwitterApi } from '../../../services/twitter/client.js';
+import {
+  OrchestratorConfig,
+  OrchestratorInput,
+  OrchestratorPrompts,
+  OrchestratorState,
+} from './types.js';
+import { BaseMessage } from '@langchain/core/messages';
 import { workflowControlParser } from './prompts.js';
-import { VectorDB } from '../../../services/vectorDb/VectorDB.js';
+import { StructuredToolInterface } from '@langchain/core/tools';
+import { RunnableToolLike } from '@langchain/core/runnables';
 
 const logger = createLogger('orchestrator-workflow');
 
-export const createWorkflowConfig = async (): Promise<OrchestratorConfig> => {
-  const { USERNAME, PASSWORD, COOKIES_PATH } = config.twitterConfig;
-  const twitterApi = await createTwitterApi(USERNAME, PASSWORD, COOKIES_PATH);
-  const vectorDb = new VectorDB('data/orchestrator');
-
-  const { tools } = createTools(twitterApi, vectorDb);
+const createWorkflowConfig = async (
+  tools: (StructuredToolInterface | RunnableToolLike)[],
+  prompts: OrchestratorPrompts,
+): Promise<OrchestratorConfig> => {
   const toolNode = new ToolNode(tools);
   const orchestratorModel = LLMFactory.createModel(config.llmConfig.nodes.orchestrator).bind({
     tools,
   });
-  const prompts = await createPrompts();
   return { orchestratorModel, toolNode, prompts };
 };
 
@@ -78,12 +78,15 @@ const createOrchestratorWorkflow = async (nodes: Awaited<ReturnType<typeof creat
   return workflow;
 };
 
-type OrchestratorRunner = Readonly<{
+export type OrchestratorRunner = Readonly<{
   runWorkflow: (input?: OrchestratorInput) => Promise<unknown>;
 }>;
 
-const createOrchestratorRunner = async (): Promise<OrchestratorRunner> => {
-  const workflowConfig = await createWorkflowConfig();
+export const createOrchestratorRunner = async (
+  tools: (StructuredToolInterface | RunnableToolLike)[],
+  prompts: OrchestratorPrompts,
+): Promise<OrchestratorRunner> => {
+  const workflowConfig = await createWorkflowConfig(tools, prompts);
   const nodes = await createNodes(workflowConfig);
   const workflow = await createOrchestratorWorkflow(nodes);
   const memoryStore = new MemorySaver();
@@ -116,20 +119,18 @@ const createOrchestratorRunner = async (): Promise<OrchestratorRunner> => {
   };
 };
 
-// Create workflow runner with caching
 export const getOrchestratorRunner = (() => {
-  let runnerPromise: Promise<OrchestratorRunner> | null = null;
-
-  return () => {
+  let runnerPromise: Promise<OrchestratorRunner> | undefined = undefined;
+  return ({
+    prompts,
+    tools,
+  }: {
+    prompts: OrchestratorPrompts;
+    tools: (StructuredToolInterface | RunnableToolLike)[];
+  }) => {
     if (!runnerPromise) {
-      runnerPromise = createOrchestratorRunner();
+      runnerPromise = createOrchestratorRunner(tools, prompts);
     }
     return runnerPromise;
   };
 })();
-
-export const runOrchestratorWorkflow = async (input: string) => {
-  const messages = [new HumanMessage({ content: input })];
-  const runner = await getOrchestratorRunner();
-  return runner.runWorkflow({ messages });
-};

--- a/src/agents/workflows/orchestrator/tools.ts
+++ b/src/agents/workflows/orchestrator/tools.ts
@@ -1,32 +1,19 @@
 import { createTwitterWorkflowTool } from './workflowTools/twitterWorkflowTool.js';
 import { createAllTwitterTools } from '../../tools/twitterTools.js';
-import { createVectorDbInsertTool, createVectorDbSearchTool } from '../../tools/vectorDbTools.js';
 import { TwitterApi } from '../../../services/twitter/types.js';
-import { VectorDB } from '../../../services/vectorDb/VectorDB.js';
 import { createSaveExperienceTool } from '../../tools/saveExperienceTool.js';
 import { createGetCurrentTimeTool } from '../../tools/getTimeTool.js';
-export const createTools = (twitterApi: TwitterApi, vectorDb: VectorDB) => {
+export const createTools = (twitterApi: TwitterApi) => {
   const twitterWorkflowTool = createTwitterWorkflowTool();
   const twitterTools = createAllTwitterTools(twitterApi);
-  const vectorDbSearchTool = createVectorDbSearchTool(vectorDb);
-  const vectorDbInsertTool = createVectorDbInsertTool(vectorDb);
   const saveExperienceTool = createSaveExperienceTool();
   const getCurrentTimeTool = createGetCurrentTimeTool();
 
   return {
     ...twitterTools,
     twitterWorkflowTool,
-    vectorDbSearchTool,
-    vectorDbInsertTool,
     saveExperienceTool,
     getCurrentTimeTool,
-    tools: [
-      ...twitterTools.tools,
-      twitterWorkflowTool,
-      vectorDbSearchTool,
-      vectorDbInsertTool,
-      saveExperienceTool,
-      getCurrentTimeTool,
-    ],
+    tools: [...twitterTools.tools, twitterWorkflowTool, saveExperienceTool, getCurrentTimeTool],
   };
 };

--- a/src/agents/workflows/orchestrator/types.ts
+++ b/src/agents/workflows/orchestrator/types.ts
@@ -6,12 +6,14 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 
+export type OrchestratorPrompts = {
+  inputPrompt: ChatPromptTemplate;
+};
+
 export type OrchestratorConfig = {
   orchestratorModel: Runnable<BaseLanguageModelInput, AIMessageChunk>;
   toolNode: ToolNode;
-  prompts: {
-    inputPrompt: ChatPromptTemplate;
-  };
+  prompts: OrchestratorPrompts;
 };
 
 export type OrchestratorInput = {


### PR DESCRIPTION
We want to move to being able to create custom agents that follow the orchestrator workflow and can then be exposed as tools to higher level agents. This PR is the first step in generalizing the orchestrator with custom tools and prompts. The way it is instantiated in `index.ts` is still a hack, using tools and prompts from the orchestration workflow. This will be cleaned up in a follow-up PR that will create a more autonomous twitter agent based on the generalized orchestrator workflow.