### PR TITLE
Fix healthcheck connection bug in memory-viewer

### DIFF
--- a/agent-memory-viewer/backend/src/utils/agentMemoryContract.ts
+++ b/agent-memory-viewer/backend/src/utils/agentMemoryContract.ts
@@ -92,7 +92,6 @@ class AgentWatcher {
 
     this.reconnectTimeout = setTimeout(async () => {
       try {
-        // Ensure we're fully stopped before attempting to reconnect
         await this.stop();
         
         // Clear any existing state

--- a/agent-memory-viewer/backend/src/utils/agentMemoryContract.ts
+++ b/agent-memory-viewer/backend/src/utils/agentMemoryContract.ts
@@ -51,9 +51,18 @@ class AgentWatcher {
 
     this.healthCheckInterval = setInterval(async () => {
       try {
-        const _res = await this.contract.getLastMemoryHash(this.agentAddress);
+        const timeoutPromise = new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('Health check timeout')), 5000);
+        });
+        
+        const healthCheckPromise = this.contract.getLastMemoryHash(this.agentAddress);
+        
+        await Promise.race([healthCheckPromise, timeoutPromise]);
+        logger.info(`Health check passed for agent ${this.agentName}`);
       } catch (error) {
-        logger.warn(`Health check failed for agent ${this.agentName}, reconnecting...`);
+        logger.warn(`Health check failed for agent ${this.agentName}, reconnecting...`, {
+          error: error instanceof Error ? error.message : String(error)
+        });
         this.handleConnectionError(error as Error);
       }
     }, this.HEALTH_CHECK_INTERVAL);
@@ -69,22 +78,42 @@ class AgentWatcher {
       clearTimeout(this.reconnectTimeout);
     }
 
-    // Even if max retries reached, keep trying with longer delays
-    const delay = RECONNECT_DELAY * Math.pow(2, Math.min(this.retryCount, 6));
+    // Cap the retry count to prevent excessive delays while still maintaining exponential backoff
+    const MAX_RETRY_COUNT = 10;
+    const currentRetryCount = Math.min(this.retryCount, MAX_RETRY_COUNT);
+    const delay = Math.min(
+      RECONNECT_DELAY * Math.pow(2, currentRetryCount),
+      60000 // Max 1 minute delay
+    );
+    
     this.retryCount++;
 
-    logger.info(`Attempting to reconnect for agent ${this.agentName} (attempt ${this.retryCount})`);
+    logger.info(`Attempting to reconnect for agent ${this.agentName} (attempt ${this.retryCount}, delay: ${delay}ms)`);
 
     this.reconnectTimeout = setTimeout(async () => {
       try {
+        // Ensure we're fully stopped before attempting to reconnect
         await this.stop();
+        
+        // Clear any existing state
+        if (this.healthCheckInterval) {
+          clearInterval(this.healthCheckInterval);
+          this.healthCheckInterval = undefined;
+        }
+        
+        // Reinitialize everything
         await this.initializeConnection();
         await this.start();
+        
         this.retryCount = 0; // Reset retry count on successful reconnection
         logger.info(`Successfully reconnected for agent ${this.agentName}`);
       } catch (error) {
         logger.error(`Reconnection failed for agent ${this.agentName}:`, error);
-        this.reconnect(); // Always try to reconnect
+        // Ensure we're in a clean state before trying again
+        await this.stop().catch(stopError => 
+          logger.error(`Error stopping during reconnection for ${this.agentName}:`, stopError)
+        );
+        this.reconnect(); // Schedule next reconnection attempt
       }
     }, delay);
   }


### PR DESCRIPTION
This pull request includes several improvements to the `AgentWatcher` class in the `agent-memory-viewer/backend/src/utils/agentMemoryContract.ts` file. The changes primarily focus on enhancing the health check mechanism and improving the reconnection logic.

### Improvements to health check mechanism:
* Introduced a timeout for the health check to prevent it from hanging indefinitely. The health check now races between the actual health check promise and a timeout promise, logging a success message if the health check passes.
* Enhanced the logging of health check failures to include the error message for better debugging.

### Improvements to reconnection logic:
* Added a cap to the retry count to prevent excessive delays while maintaining exponential backoff, with a maximum delay of 1 minute.
* Ensured the system is fully stopped and cleared any existing state before attempting to reconnect, and reinitialized everything upon reconnection.
* Improved logging to include the delay for each reconnection attempt and ensured the system is in a clean state before scheduling the next reconnection attempt.