### PR TITLE
Only bind tools to input node

### DIFF
--- a/src/agents/workflows/orchestrator/nodes/inputNode.ts
+++ b/src/agents/workflows/orchestrator/nodes/inputNode.ts
@@ -18,16 +18,18 @@ const parseWorkflowControl = async (content: unknown) => {
   return undefined;
 };
 
-export const createInputNode = ({ orchestratorModel, prompts }: OrchestratorConfig) => {
+export const createInputNode = ({ orchestratorModel, prompts, toolNode }: OrchestratorConfig) => {
   const runNode = async (state: typeof OrchestratorState.State) => {
     const { messages } = state;
     logger.info('Running input node with messages:', {
       messages: messages.map(message => message.content),
     });
+
     const formattedPrompt = await prompts.inputPrompt.format({
       messages: messages.map(message => message.content),
     });
-    const result = await orchestratorModel.invoke(formattedPrompt);
+
+    const result = await orchestratorModel.bind({ tools: toolNode.tools }).invoke(formattedPrompt);
 
     const usage = result.additional_kwargs?.usage as
       | { input_tokens: number; output_tokens: number }

--- a/src/agents/workflows/orchestrator/nodes/workflowSummaryPrompt.ts
+++ b/src/agents/workflows/orchestrator/nodes/workflowSummaryPrompt.ts
@@ -6,7 +6,7 @@ export const createWorkflowSummaryPrompt = async (customInstructions?: string) =
   const character = config.characterConfig;
 
   const workflowSummarySystemPrompt = await PromptTemplate.fromTemplate(
-    `Summarize the following mesages in detail. This is being returned as a report to what was accomplished during the execution of the workflow. DO NOT recommend tool usage, just summarize the messages!
+    `Summarize the following messages in detail. This is being returned as a report to what was accomplished during the execution of the workflow.
 
     You have a personality, so you should act accordingly.
     {characterDescription}

--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -20,9 +20,7 @@ const createWorkflowConfig = async (
   prompts: OrchestratorPrompts,
 ): Promise<OrchestratorConfig> => {
   const toolNode = new ToolNode(tools);
-  const orchestratorModel = LLMFactory.createModel(config.llmConfig.nodes.orchestrator).bind({
-    tools,
-  });
+  const orchestratorModel = LLMFactory.createModel(config.llmConfig.nodes.orchestrator);
   return { orchestratorModel, toolNode, prompts };
 };
 

--- a/src/agents/workflows/orchestrator/types.ts
+++ b/src/agents/workflows/orchestrator/types.ts
@@ -7,6 +7,7 @@ import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { config } from '../../../config/index.js';
 import { WorkflowControl } from './nodes/inputPrompt.js';
+import { LLMModelType } from '../../../services/llm/factory.js';
 
 export type OrchestratorPrompts = {
   inputPrompt: ChatPromptTemplate;
@@ -15,7 +16,7 @@ export type OrchestratorPrompts = {
 };
 
 export type OrchestratorConfig = {
-  orchestratorModel: Runnable<BaseLanguageModelInput, AIMessageChunk>;
+  orchestratorModel: LLMModelType;
   toolNode: ToolNode;
   prompts: OrchestratorPrompts;
 };

--- a/src/services/llm/factory.ts
+++ b/src/services/llm/factory.ts
@@ -49,3 +49,5 @@ export class LLMFactory {
     }
   }
 }
+
+export type LLMModelType = ReturnType<typeof LLMFactory.createModelFromConfig>;


### PR DESCRIPTION
Currently, we bind tools to the orchestrator model at the config level. However, we only want tools bound during the input node execution. This PR moves binding of tools to the orchestrator model call in the input node.

### Orchestrator Model and Tool Node Configuration:

* [`src/agents/workflows/orchestrator/nodes/inputNode.ts`](diffhunk://#diff-0b266f27dd6b3b72ff592a029a20a2e6b185b4a148a142c29da1c950e6f1b3aaL21-R32): Updated the `createInputNode` function to include `toolNode` in the `OrchestratorConfig` and bind tools to the orchestrator model before invoking it.
* [`src/agents/workflows/orchestrator/orchestratorWorkflow.ts`](diffhunk://#diff-b4dfd7878eec16efd1a0380da0464e07cc47af54ed1dc55b5fc0aefef7644059L23-R23): Modified the `createWorkflowConfig` function to remove the binding of tools to the orchestrator model during its creation.

### Prompt and Type Adjustments:

* [`src/agents/workflows/orchestrator/nodes/workflowSummaryPrompt.ts`](diffhunk://#diff-dc9d6e08725c40786fd5ba7e17499fdeb01e6eb1f83549e6a7f573248e1d6d99L9-R9): Corrected a typo in the workflow summary system prompt template.
* [`src/agents/workflows/orchestrator/types.ts`](diffhunk://#diff-e1ae794f3d517bc8bfa38589ea4a340b93eef612ebc9dd6f8ce89c97cf881328R10): Added an import for `LLMModelType` and updated the `OrchestratorConfig` type to use `LLMModelType` for the `orchestratorModel` property. [[1]](diffhunk://#diff-e1ae794f3d517bc8bfa38589ea4a340b93eef612ebc9dd6f8ce89c97cf881328R10) [[2]](diffhunk://#diff-e1ae794f3d517bc8bfa38589ea4a340b93eef612ebc9dd6f8ce89c97cf881328L18-R19)

### New Type Definition:

* [`src/services/llm/factory.ts`](diffhunk://#diff-952ead934ec6ef86dfac8e448f9d687c4b3e749bbdba9ae1326c66791346d3ceR52-R53): Added a new type definition `LLMModelType` representing the return type of the `createModelFromConfig` method in `LLMFactory`.