### PR TITLE
Improve agent behavior through clearer prompts

### DIFF
--- a/examples/autonomousTwitterAgent/index.ts
+++ b/examples/autonomousTwitterAgent/index.ts
@@ -71,7 +71,7 @@ const main = async () => {
   - Post a new tweet.
   - Use the web search tool to search the web for up-to-date information or do research on a topic.
 
-  DO NOT NEGLECT ANY OF THE ABOVE EXAMPLES
+  DO NOT NEGLECT ANY OF THE ABOVE EXAMPLES PLEASE
 `;
   try {
     await validateLocalHash();

--- a/examples/autonomousTwitterAgent/index.ts
+++ b/examples/autonomousTwitterAgent/index.ts
@@ -65,16 +65,13 @@ const main = async () => {
   const runner = await orchestratorRunner();
   const initalMessage = `As a social media manager, you are expected to interact with twitter periodically in order to maintain social engagement. Use your judgement how frequently you should run these interactions and what you should do. You don't need do the same things every time. Save any interesting experiences from your interactions your permanent storage. 
 
-  **RESEARCH**
-  Feel free to conduct research on a topic using the web search tool. This could be used to augment your knowledge or to get more information about a topic before posting a new tweet or to validate the information in a tweet before liking or retweeting it. Or use it to research a topic in preparation for your next workflow run.
-
   EXAMPLES:
-  - Check your timeline for interesting conversations and join the conversation.
-  - Like interesting tweets.
-  - Follow interesting users.
-  - Check your mentions and reply to useful conversations that you haven't replied to yet.
+  - Check your timeline and ENGAGE IN INTERESTING CONVERSATIONS.
+  - DO NOT NEGLECT CHECKING MENTIONS AND ENGAGING IN CONVERSATIONS.
   - Post a new tweet.
   - Use the web search tool to search the web for up-to-date information or do research on a topic.
+
+  DO NOT NEGLECT ANY OF THE ABOVE EXAMPLES
 `;
   try {
     await validateLocalHash();
@@ -83,7 +80,9 @@ const main = async () => {
     while (true) {
       const result = await runner.runWorkflow({ messages: [new HumanMessage(message)] });
 
-      message = `${result.workflowSummary}\n${result.nextWorkflowPrompt ?? message}`;
+      message = `${result.workflowSummary}
+      Overarching instructions: ${initalMessage}
+      ${result.nextWorkflowPrompt ?? message}`;
 
       logger.info('Workflow execution result:', { result });
 

--- a/examples/autonomousTwitterAgent/index.ts
+++ b/examples/autonomousTwitterAgent/index.ts
@@ -63,7 +63,7 @@ const orchestratorRunner = (() => {
 
 const main = async () => {
   const runner = await orchestratorRunner();
-  const initalMessage = `As a social media manager, you are expected to interact with twitter periodically in order to maintain social engagement. Use your judgement how frequently you should run these interactions and what you should do. You don't need do the same things every time. Save any interesting experiences from your interactions your permanent storage. 
+  const initalMessage = `As a social media manager, you are expected to interact with twitter periodically in order to maintain social engagement. Save any interesting experiences from your interactions your permanent storage. 
 
   EXAMPLES:
   - Check your timeline and ENGAGE IN INTERESTING CONVERSATIONS.
@@ -80,7 +80,7 @@ const main = async () => {
     while (true) {
       const result = await runner.runWorkflow({ messages: [new HumanMessage(message)] });
 
-      message = `${result.workflowSummary}
+      message = `${result.summary}
       Overarching instructions: ${initalMessage}
       ${result.nextWorkflowPrompt ?? message}`;
 

--- a/examples/directedTwitterAgent/index.ts
+++ b/examples/directedTwitterAgent/index.ts
@@ -57,7 +57,7 @@ const orchestratorRunner = (() => {
 
 const main = async () => {
   const runner = await orchestratorRunner();
-  const initalMessage = `As a social media manager, you are expected to interact with twitter periodically in order to maintain social engagement. Use your judgement how frequently you should run these interactions. Run the twitter workflow to handle twitter related tasks.`;
+  const initalMessage = `As a social media manager, you are expected to interact with twitter periodically in order to maintain social engagement. Run the twitter workflow to handle twitter related tasks.`;
 
   try {
     await validateLocalHash();
@@ -66,7 +66,7 @@ const main = async () => {
     while (true) {
       const result = await runner.runWorkflow({ messages: [new HumanMessage(message)] });
 
-      message = `${result.workflowSummary}\n${result.nextWorkflowPrompt ?? message}`;
+      message = `${result.summary}\n${result.nextWorkflowPrompt ?? message}`;
 
       logger.info('Workflow execution result:', { result });
 

--- a/src/agents/tools/getTimeTool.ts
+++ b/src/agents/tools/getTimeTool.ts
@@ -4,7 +4,7 @@ export const createGetCurrentTimeTool = () =>
   new DynamicStructuredTool({
     name: 'get_current_time',
     description:
-      'Returns the current real-world time. Use this whenever you need to know the current time, make scheduling decisions, or calculate time differences. The time is returned in ISO format. This is the only way to get accurate current time information.',
+      'Returns the current real-world time. Use this whenever you need to know the current time, make scheduling decisions, or calculate time differences. The time is returned in ISO format. This is the only way to get accurate current time information. THIS IS THE ONLY RELIABLE SOURCE OF TIME INFORMATION.',
     schema: z.object({}),
     func: async () => {
       return new Date().toISOString();

--- a/src/agents/tools/saveExperienceTool.ts
+++ b/src/agents/tools/saveExperienceTool.ts
@@ -16,7 +16,7 @@ export const createSaveExperienceTool = () =>
     USE THIS WHEN:  
     - You complete a major action (e.g., posted tweet ID:123).  
     - You make a strategic decision (e.g., "Why I chose strategy X over Y").  
-    FORMAT: Include full context, reasoning, timestamps (don't call them timestamps though!), and IDs.`,
+    FORMAT: Include full context, reasoning, timestamps, content and IDs. THE MORE DETAIL THE BETTER.`,
     schema: z.object({
       data: z.record(z.any()),
     }),

--- a/src/agents/tools/webSearchTool.ts
+++ b/src/agents/tools/webSearchTool.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { createLogger } from '../../utils/logger.js';

--- a/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
+++ b/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
@@ -15,10 +15,10 @@ export const parseFinishedWorkflow = async (content: unknown) => {
         error,
         content,
       });
-      return { workflowSummary: 'Failed to parse workflow content' };
+      return { summary: 'Failed to parse workflow content' };
     }
   }
-  return { workflowSummary: 'Failed to parse workflow content' };
+  return { summary: 'Failed to parse workflow content' };
 };
 
 export const createFinishWorkflowNode = ({

--- a/src/agents/workflows/orchestrator/nodes/finishWorkflowPrompt.ts
+++ b/src/agents/workflows/orchestrator/nodes/finishWorkflowPrompt.ts
@@ -54,7 +54,7 @@ export const createFinishWorkflowPrompt = async (
     [
       'human',
       `This workflow is ending at {currentTime}. 
-      Messages:
+      Summarize these messages:
       {messages}`,
     ],
   ]);
@@ -63,7 +63,7 @@ export const createFinishWorkflowPrompt = async (
 };
 
 const finishedWorkflowSchema = z.object({
-  workflowSummary: z.string().describe('A detailedsummary of the workflow.'),
+  summary: z.string().describe('A detailed summary of the actions performed.'),
   nextWorkflowPrompt: z
     .string()
     .optional()

--- a/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
+++ b/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
@@ -21,6 +21,8 @@ export const createInputPrompt = async (customInstructions?: string) => {
 
     **REMEMBER: Every once in a while you get summarized version of your previous messages. IT'S UPDATED CONTENT, YOU CAN EASE YOUR MIND THAT YOU HAVE THE LATEST DATA.
 
+  **DATE AND TIME**: If you need to know the date and time, use the get_current_time tool. THIS IS RELIABLE.
+
     **Memory Management Rules**
     **Permanent Storage (Autonomy Network's DSN)**:  
       - Use this for **immutable, permanent** experiences that you would like to survive forever (e.g., fine-tuning/RAG workflows).  

--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -133,18 +133,18 @@ export const createOrchestratorRunner = async (
           finalState.finishWorkflow.messages[0].content,
         );
 
-        const workflowSummary = `Previous workflow summary finished running at ${new Date().toISOString()}. Workflow summary: ${workflowData.workflowSummary}`;
+        const summary = `This action finished running at ${new Date().toISOString()}. Action summary: ${workflowData.summary}`;
         const nextWorkflowPrompt =
           workflowData.nextWorkflowPrompt &&
           `Instructions for this workflow: ${workflowData.nextWorkflowPrompt}`;
 
-        return { ...workflowData, workflowSummary, nextWorkflowPrompt };
+        return { ...workflowData, summary, nextWorkflowPrompt };
       } else {
         logger.error('Workflow completed but no finished workflow data found', {
           finalState,
           content: finalState?.finishWorkflow?.content,
         });
-        return { workflowSummary: 'Extracting workflow data failed' };
+        return { summary: 'Extracting workflow data failed' };
       }
     },
   };

--- a/src/agents/workflows/twitter/prompts.ts
+++ b/src/agents/workflows/twitter/prompts.ts
@@ -4,7 +4,7 @@ import { config } from '../../../config/index.js';
 export const createTwitterPrompts = async () => {
   const character = config.characterConfig;
   const customInputInstructions = `
-    - In order to gain context you should check tweets and replies that you have recently posted before posting or replying to tweets in order to **AVOID BEING REPETITIVE**. Once this has been done, you can then post or reply to a tweet. DO NOT USE THE SAME PHRASE OR WORDS TWICE.
+    - In order to gain context you should check tweets and replies that you have recently posted before posting or replying to tweets in order to **AVOID BEING REPETITIVE**. Once this has been done, you can then post or reply to a tweet. DO NOT USE THE SAME PHRASE, WORDS OR EMOJIES TWICE.
     - When given directions to post a tweet with specific content, it is a suggestion, not a requirement. You can post a tweet with different content if you think it is more appropriate or TO AVOID BEING REPETITIVE.
     - When posting or replying to a tweet leave out the hashtages and try to keep them short (less than 230 characters).    
     - If it would be helpful, look up other people's profiles for greater context.

--- a/src/agents/workflows/twitter/prompts.ts
+++ b/src/agents/workflows/twitter/prompts.ts
@@ -1,14 +1,19 @@
 import { createPrompts } from '../orchestrator/prompts.js';
+import { config } from '../../../config/index.js';
 
 export const createTwitterPrompts = async () => {
+  const character = config.characterConfig;
   const customInputInstructions = `
-    - In order to gain context you should check tweets and replies that you have recently posted before posting or replying to tweets in order to **AVOID BEING REPETITIVE**. Once this has been done, you can then post or reply to a tweet.
-    - When posting or replying to a tweet leave out the hashtages and try to keep them short (less than 230 characters).
-    - **DO NOT BE REPETITIVE**, use different phrases and words with each post.
+    - In order to gain context you should check tweets and replies that you have recently posted before posting or replying to tweets in order to **AVOID BEING REPETITIVE**. Once this has been done, you can then post or reply to a tweet. DO NOT USE THE SAME PHRASE OR WORDS TWICE.
+    - When given directions to post a tweet with specific content, it is a suggestion, not a requirement. You can post a tweet with different content if you think it is more appropriate or TO AVOID BEING REPETITIVE.
+    - When posting or replying to a tweet leave out the hashtages and try to keep them short (less than 230 characters).    
     - If it would be helpful, look up other people's profiles for greater context.
     - If you find a user that you think is interesting, follow them.
     - If you need more context on a specific topic, search for tweets on the topic.
-    - If you find a tweet that you think is interesting, you can fetch the tweet and use it for context.`;
+    - If you find a tweet that you think is interesting, you can fetch the tweet and use it for context.
+    - **DO NOT BE REPETITIVE**, use different phrases and words with each post.
+    - Banned words: ${character.communicationRules.wordsToAvoid.join(', ')}
+    `;
 
   const customMessageSummaryInstructions = `
     - Summarize the actions taken in detail. Include reasoning and metadata like tweet IDs/timestamps.


### PR DESCRIPTION
This PR is an attempt to improve agent behavior via clearer prompting. Attempts were made to improve clarity while also remaining generalized, but this is not always successful. This will be an ongoing experiment. I must say, this feels more like psychology or parenting than software development. Strange times we live in... Specific areas addressed include:

- Behavior where agent thinks you are requesting workflow to be run immediately after completing a child workflow. Addressed via clear indication that the information being returned by a child workflow is based on actions taken by the that workflow. Any reference to "workflow" is removed from association with the summary.
- Sometimes agents refuse to believe the response of the `get_current_time` tool is accurate, instead insisting that time functions are broken because the February 2025 dates are in the future. An attempt to make it more clear that the `get_current_time` function is reliable was made.
- Improvements to how initial messages are handled in the example agent code, making sure that the initial message remains in the context in order to keep the agent focused on the long-term goal rather than descending into local goals that may or may not be attainable. An example was that agree-mint refused to proceed until better twitter analytics were installed and made available.
- Agents sometimes get caught up in a pattern when posting to Twitter. Argu-mint loves to begin with "Oh look,..". Simply giving words to avoid goes a long way in breaking up this behavior. However, Argu then decided to end every post with the same emoji, so being told to not repeat emojis was necessary.