### PR TITLE
Add git build for agent framework

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,3 +50,24 @@ jobs:
 
       - name: Build project 🔧
         run: yarn build
+
+  build-agent-framework:
+    runs-on: ubuntu-latest
+    name: Build Agent Framework
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js 📦
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+
+      - name: Enable Corepack 📦
+        run: corepack enable
+
+      - name: Install dependencies 📦
+        run: yarn install
+
+      - name: Build project 🔧
+        run: yarn build


### PR DESCRIPTION
This pull request introduces a new job in the GitHub Actions workflow to build the Agent Framework. The most important change includes adding a new job definition in the `.github/workflows/build.yaml` file.

New job added to the GitHub Actions workflow:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R53-R73): Added a new job named `build-agent-framework` that runs on `ubuntu-latest`, checks out the repository, sets up Node.js, enables Corepack, installs dependencies, and builds the project.