### PR TITLE
Return Tweet ID after Posting Tweet and Tool Cleanup

### DIFF
--- a/examples/twitterAgent/index.ts
+++ b/examples/twitterAgent/index.ts
@@ -24,7 +24,7 @@ const orchestratorConfig = async () => {
   const twitterAgent = createTwitterAgentTool(twitterApi, [webSearchTool]);
 
   const namespace = 'orchestrator';
-  const { tools } = createTools();
+  const tools = createTools();
   const prompts = await createPrompts({ selfSchedule: true });
   const pruningParameters: PruningParameters = {
     maxWindowSummary: 30,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -23,7 +23,7 @@ const orchestratorConfig = async () => {
 
   //Orchestrator config
   const namespace = 'orchestrator';
-  const { tools } = createTools();
+  const tools = createTools();
   const prompts = await createPrompts({ selfSchedule: true });
   const pruningParameters: PruningParameters = {
     maxWindowSummary: 30,

--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -227,25 +227,20 @@ export const createPostTweetTool = (twitterApi: TwitterApi) =>
   new DynamicStructuredTool({
     name: 'post_tweet',
     description: 'Post a tweet',
-    schema: z.object({ tweet: z.string(), inReplyTo: z.string().optional() }),
-    func: async ({ tweet, inReplyTo }: { tweet: string; inReplyTo?: string }) => {
+    schema: z.object({ text: z.string(), inReplyTo: z.string().optional() }),
+    func: async ({ text, inReplyTo }: { text: string; inReplyTo?: string }) => {
       try {
         if (config.twitterConfig.POST_TWEETS) {
-          const postedTweet = await twitterApi
-            .sendTweet(tweet, inReplyTo)
-            .then(_ =>
-              !inReplyTo ? twitterApi.scraper.getLatestTweet(twitterApi.username) : undefined,
-            );
-
+          const postedTweetId = await twitterApi.sendTweet(text, inReplyTo);
           logger.info('Tweet posted successfully', {
-            postedTweet: { id: postedTweet?.id, text: postedTweet?.text },
+            postedTweet: { postedTweetId, text },
           });
           return {
             postedTweet: true,
-            postedTweetId: postedTweet?.id,
+            postedTweetId,
           };
         } else {
-          logger.info('Tweet not posted', { tweet });
+          logger.info('Tweet not posted', { text });
           return {
             postedTweet: false,
             message:

--- a/src/agents/tools/twitterTools.ts
+++ b/src/agents/tools/twitterTools.ts
@@ -290,7 +290,7 @@ export const createAllTwitterTools = (twitterApi: TwitterApi) => {
   const fetchProfileTool = createFetchProfileTool(twitterApi);
   const fetchFollowingTool = createFetchFollowingTool(twitterApi);
 
-  return {
+  return [
     fetchTimelineTool,
     fetchFollowingTimelineTool,
     fetchMentionsTool,
@@ -302,18 +302,5 @@ export const createAllTwitterTools = (twitterApi: TwitterApi) => {
     postTweetTool,
     likeTweetTool,
     followUserTool,
-    tools: [
-      fetchTimelineTool,
-      fetchFollowingTimelineTool,
-      fetchMentionsTool,
-      fetchMyRecentTweetsAndRepliesTool,
-      searchTweetsTool,
-      fetchTweetTool,
-      fetchProfileTool,
-      fetchFollowingTool,
-      postTweetTool,
-      likeTweetTool,
-      followUserTool,
-    ],
-  };
+  ];
 };

--- a/src/agents/workflows/orchestrator/tools.ts
+++ b/src/agents/workflows/orchestrator/tools.ts
@@ -4,9 +4,5 @@ export const createTools = () => {
   const saveExperienceTool = createSaveExperienceTool();
   const getCurrentTimeTool = createGetCurrentTimeTool();
 
-  return {
-    saveExperienceTool,
-    getCurrentTimeTool,
-    tools: [saveExperienceTool, getCurrentTimeTool],
-  };
+  return [saveExperienceTool, getCurrentTimeTool];
 };

--- a/src/agents/workflows/twitter/tools.ts
+++ b/src/agents/workflows/twitter/tools.ts
@@ -10,11 +10,5 @@ export const createTools = (twitterApi: TwitterApi, vectorDb: VectorDB) => {
   const saveExperienceTool = createSaveExperienceTool();
   const getCurrentTimeTool = createGetCurrentTimeTool();
   const vectorDbSearchTool = createVectorDbSearchTool(vectorDb);
-  return {
-    ...twitterTools,
-    saveExperienceTool,
-    getCurrentTimeTool,
-    vectorDbSearchTool,
-    tools: [...twitterTools, saveExperienceTool, getCurrentTimeTool, vectorDbSearchTool],
-  };
+  return [...twitterTools, saveExperienceTool, getCurrentTimeTool, vectorDbSearchTool];
 };

--- a/src/agents/workflows/twitter/tools.ts
+++ b/src/agents/workflows/twitter/tools.ts
@@ -15,6 +15,6 @@ export const createTools = (twitterApi: TwitterApi, vectorDb: VectorDB) => {
     saveExperienceTool,
     getCurrentTimeTool,
     vectorDbSearchTool,
-    tools: [...twitterTools.tools, saveExperienceTool, getCurrentTimeTool, vectorDbSearchTool],
+    tools: [...twitterTools, saveExperienceTool, getCurrentTimeTool, vectorDbSearchTool],
   };
 };

--- a/src/agents/workflows/twitter/twitterAgentTool.ts
+++ b/src/agents/workflows/twitter/twitterAgentTool.ts
@@ -27,7 +27,7 @@ export const createTwitterAgentTool = (twitterApi: TwitterApi, optionalTools: To
         const namespace = 'twitter';
 
         const vectorStore = new VectorDB(namespace);
-        const { tools } = createTools(twitterApi, vectorStore);
+        const tools = createTools(twitterApi, vectorStore);
         const model = LLMFactory.createModel({
           provider: LLMProvider.ANTHROPIC,
           model: 'claude-3-5-sonnet-latest',

--- a/src/services/twitter/types.ts
+++ b/src/services/twitter/types.ts
@@ -19,7 +19,7 @@ export interface TwitterApi {
   getMyTimeline: (count: number, excludeIds: string[]) => Promise<Tweet[]>;
   getFollowingTimeline: (count: number, excludeIds: string[]) => Promise<Tweet[]>;
   searchTweets: (query: string, count: number) => Promise<Tweet[]>;
-  sendTweet: (tweet: string, inReplyTo?: string) => Promise<void>;
+  sendTweet: (tweet: string, inReplyTo?: string) => Promise<string>;
   likeTweet: (tweetId: string) => Promise<void>;
   followUser: (username: string) => Promise<void>;
 }


### PR DESCRIPTION
Closes #95 

This pull request includes several changes to the Twitter agent tools and orchestrator configurations. The primary focus is on simplifying the tool creation process and improving the tweet posting functionality.

### Simplification of tool creation:

* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75L298-R293): Changed the return type of `createAllTwitterTools` to an array instead of an object. [[1]](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75L298-R293) [[2]](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75L310-R305)
* [`src/agents/workflows/orchestrator/tools.ts`](diffhunk://#diff-55b82f5fb1f170f81a7e10c667ea1ad850222cc4534cafb9784a12b4781e9a49L7-R7): Changed the return type of `createTools` to an array instead of an object.
* [`src/agents/workflows/twitter/tools.ts`](diffhunk://#diff-63ae8a13aceacff3f9f7eed64cfb1c5afa186b3f7bfdd93dd42e49e14759e601L18-R18): Adjusted the `createTools` function to use the updated return type from `twitterTools`.

### Improvements to tweet posting functionality:

* [`src/agents/tools/twitterTools.ts`](diffhunk://#diff-230c660f4e65058334d197eecd5d08fa4631f93b723a7648314029959f810c75L230-R243): Updated the `post_tweet` tool to use `text` instead of `tweet` and implemented a retry strategy to confirm the tweet ID.
* [`src/services/twitter/client.ts`](diffhunk://#diff-9630eb2796eecdfade33ba5ad88277b7d43c3d8f2d1bd32765da2ba202133addL310-R344): Modified the `sendTweet` function to return the tweet ID and implemented a retry strategy to confirm the tweet ID.
* [`src/services/twitter/types.ts`](diffhunk://#diff-144b848be0667715dbe00f1e7598ac1fab28c950a03175a31ec59c8e2872bd17L22-R22): Updated the `sendTweet` function signature to return a `Promise<string>` instead of `Promise<void>`.

### Consistency in orchestrator configuration:

* `examples/twitterAgent/index.ts` and `src/agent.ts`: Simplified the `createTools` call by removing destructuring. [[1]](diffhunk://#diff-b53615d38e5708e50f68e83b8a6dd0f9a1c3abddf56555240661d0ae643cb5a4L27-R27) [[2]](diffhunk://#diff-49cc4f0909411e6de89a20d5a97f81c481546b48973288ba70aeb002b0dd4138L26-R26)