### PR TITLE
Bug: Agents post replies to same tweet multiple times

### DIFF
--- a/src/agents/tools/twitter/index.ts
+++ b/src/agents/tools/twitter/index.ts
@@ -57,6 +57,7 @@ export const createFetchFollowingTimelineTool = (twitterApi: TwitterApi) =>
       processedIds: string[];
     }) => {
       const myReplies = await twitterApi.getMyRepliedToIds();
+      logger.info('myReplies', { myReplies });
       const tweets = (
         await twitterApi.getFollowingTimeline(numFollowingTimelineTweets, [
           ...processedIds,
@@ -200,6 +201,17 @@ export const createPostTweetTool = (twitterApi: TwitterApi, postTweets: boolean 
     func: async ({ text, inReplyTo }: { text: string; inReplyTo?: string }) => {
       try {
         if (postTweets) {
+          if (inReplyTo) {
+            const myReplies = await twitterApi.getMyRepliedToIds();
+            const hasRepliedTo = myReplies.includes(inReplyTo);
+            if (hasRepliedTo) {
+              logger.info('Already replied to this tweet', { inReplyTo });
+              return {
+                postedTweet: false,
+                message: 'Already replied to this tweet',
+              };
+            }
+          }
           const postedTweetId = await twitterApi.sendTweet(text, inReplyTo);
           logger.info('Tweet posted successfully', {
             postedTweet: { postedTweetId, text },

--- a/src/agents/tools/twitter/index.ts
+++ b/src/agents/tools/twitter/index.ts
@@ -23,9 +23,10 @@ export const createFetchTimelineTool = (twitterApi: TwitterApi) =>
       numTimelineTweets: number;
     }) => {
       try {
-        const tweets = (await twitterApi.getMyTimeline(numTimelineTweets, processedIds)).map(t =>
-          tweetToMinimalTweet(t),
-        );
+        const myReplies = await twitterApi.getMyRepliedToIds();
+        const tweets = (
+          await twitterApi.getMyTimeline(numTimelineTweets, [...processedIds, ...myReplies])
+        ).map(t => tweetToMinimalTweet(t));
 
         logger.info('Timeline tweets:', {
           timelineTweets: tweets.length,
@@ -55,8 +56,12 @@ export const createFetchFollowingTimelineTool = (twitterApi: TwitterApi) =>
       numFollowingTimelineTweets: number;
       processedIds: string[];
     }) => {
+      const myReplies = await twitterApi.getMyRepliedToIds();
       const tweets = (
-        await twitterApi.getFollowingTimeline(numFollowingTimelineTweets, processedIds)
+        await twitterApi.getFollowingTimeline(numFollowingTimelineTweets, [
+          ...processedIds,
+          ...myReplies,
+        ])
       ).map(t => tweetToMinimalTweet(t));
       return { tweets };
     },


### PR DESCRIPTION
This pull request fixes an issue where agents would post replies to same tweet multiple times. The most changes update the `createFetchTimelineTool` and `createFetchFollowingTimelineTool` functions to exclude replied-to tweet IDs when fetching timelines.

* [`src/agents/tools/twitter/index.ts`](diffhunk://#diff-68013515fdfb5afcfacecec26f158f622461c5e4a30072c0bfcd9d1f4d4d1d6cL26-R29): Updated the `createFetchTimelineTool` function to fetch replied-to tweet IDs and include them in the processed IDs when retrieving the user's timeline.
* [`src/agents/tools/twitter/index.ts`](diffhunk://#diff-68013515fdfb5afcfacecec26f158f622461c5e4a30072c0bfcd9d1f4d4d1d6cR59-R64): Updated the `createFetchFollowingTimelineTool` function to fetch replied-to tweet IDs and include them in the processed IDs when retrieving the following timeline.