### PR TITLE
Add monitoring option to autodrive config

### DIFF
--- a/characters/character.example/config/config.example.yaml
+++ b/characters/character.example/config/config.example.yaml
@@ -3,4 +3,5 @@ twitter:
 
 auto_drive:
   upload: true
-  network: 'taurus' # or 'mainnet'
+  monitoring: true
+  network: 'mainnet' # or 'taurus'

--- a/examples/multiPersonality/index.ts
+++ b/examples/multiPersonality/index.ts
@@ -31,6 +31,7 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
   //shared twitter agent and orchestrator config
   const webSearchTool = config.SERPAPI_API_KEY ? [createWebSearchTool(config.SERPAPI_API_KEY)] : [];
   const autoDriveUploadEnabled = config.autoDriveConfig.AUTO_DRIVE_UPLOAD;
+  const monitoringEnabled = config.autoDriveConfig.AUTO_DRIVE_MONITORING;
 
   //Twitter agent config
   const { USERNAME, PASSWORD, COOKIES_PATH } = config.twitterConfig;
@@ -40,6 +41,9 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
     tools: [...webSearchTool],
     postTweets: config.twitterConfig.POST_TWEETS,
     autoDriveUploadEnabled,
+    monitoring: {
+      enabled: monitoringEnabled,
+    },
   });
 
   //Orchestrator config
@@ -64,6 +68,9 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
     tools: [twitterAgent, ...webSearchTool],
     prompts,
     autoDriveUploadEnabled,
+    monitoring: {
+      enabled: monitoringEnabled,
+    },
   };
 };
 

--- a/examples/twitterAgent/index.ts
+++ b/examples/twitterAgent/index.ts
@@ -20,7 +20,7 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
   //shared twitter agent and orchestrator config
   const webSearchTool = config.SERPAPI_API_KEY ? [createWebSearchTool(config.SERPAPI_API_KEY)] : [];
   const autoDriveUploadEnabled = config.autoDriveConfig.AUTO_DRIVE_UPLOAD;
-
+  const monitoringEnabled = config.autoDriveConfig.AUTO_DRIVE_MONITORING;
   //Twitter agent config
   const { USERNAME, PASSWORD, COOKIES_PATH } = config.twitterConfig;
   const twitterApi = await createTwitterApi(USERNAME, PASSWORD, COOKIES_PATH);
@@ -29,6 +29,9 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
     tools: [...webSearchTool],
     postTweets: config.twitterConfig.POST_TWEETS,
     autoDriveUploadEnabled,
+    monitoring: {
+      enabled: monitoringEnabled,
+    },
   });
 
   //Orchestrator config
@@ -53,6 +56,9 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
     tools: [twitterAgent, ...webSearchTool],
     prompts,
     autoDriveUploadEnabled,
+    monitoring: {
+      enabled: monitoringEnabled,
+    },
   };
 };
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,18 +12,21 @@ import { createTwitterApi } from './services/twitter/client.js';
 
 const character = config.characterConfig;
 const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
+  //shared twitter agent and orchestrator config
+  const webSearchTool = config.SERPAPI_API_KEY ? [createWebSearchTool(config.SERPAPI_API_KEY)] : [];
+  const autoDriveUploadEnabled = config.autoDriveConfig.AUTO_DRIVE_UPLOAD;
+  const monitoringEnabled = config.autoDriveConfig.AUTO_DRIVE_MONITORING;
+
   //Twitter agent config
   const { USERNAME, PASSWORD, COOKIES_PATH } = config.twitterConfig;
   const twitterApi = await createTwitterApi(USERNAME, PASSWORD, COOKIES_PATH);
-  const webSearchTool = createWebSearchTool(config.SERPAPI_API_KEY || '');
-  const autoDriveUploadEnabled = config.autoDriveConfig.AUTO_DRIVE_UPLOAD;
 
   const twitterAgentTool = createTwitterAgent(twitterApi, character, {
-    tools: [webSearchTool],
+    tools: [...webSearchTool],
     postTweets: config.twitterConfig.POST_TWEETS,
     autoDriveUploadEnabled,
     monitoring: {
-      enabled: true,
+      enabled: monitoringEnabled,
     },
   });
 
@@ -48,11 +51,11 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
   };
   return {
     modelConfigurations,
-    tools: [twitterAgentTool, webSearchTool],
+    tools: [twitterAgentTool, ...webSearchTool],
     prompts,
     autoDriveUploadEnabled,
     monitoring: {
-      enabled: true,
+      enabled: monitoringEnabled,
     },
   };
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -79,7 +79,7 @@ export const config = (() => {
         USERNAME: username,
         PASSWORD: process.env.TWITTER_PASSWORD || '',
         COOKIES_PATH: cookiesPath,
-        POST_TWEETS: yamlConfig.twitter.post_tweets,
+        POST_TWEETS: yamlConfig.twitter.post_tweets ?? false,
       },
 
       characterConfig,
@@ -97,7 +97,8 @@ export const config = (() => {
         AUTO_DRIVE_API_KEY: process.env.AUTO_DRIVE_API_KEY,
         AUTO_DRIVE_ENCRYPTION_PASSWORD: process.env.AUTO_DRIVE_ENCRYPTION_PASSWORD,
         AUTO_DRIVE_NETWORK: yamlConfig.auto_drive.network ?? 'taurus',
-        AUTO_DRIVE_UPLOAD: yamlConfig.auto_drive.upload ?? true,
+        AUTO_DRIVE_UPLOAD: yamlConfig.auto_drive.upload ?? false,
+        AUTO_DRIVE_MONITORING: yamlConfig.auto_drive.monitoring ?? false,
       },
 
       blockchainConfig: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,6 +25,7 @@ const autoDriveConfigSchema = z.object({
     .transform(val => NetworkId[val.toUpperCase() as 'MAINNET' | 'TAURUS'])
     .default('taurus'),
   AUTO_DRIVE_UPLOAD: z.boolean().default(true),
+  AUTO_DRIVE_MONITORING: z.boolean().default(true),
 });
 
 const blockchainConfigSchema = z.object({


### PR DESCRIPTION
Before this, the CLI default code enables monitoring. This moves it to the character config.

This pull request introduces a new feature to enable monitoring in the auto drive configuration across multiple files. The changes include updates to the configuration files, schema, and relevant TypeScript files to support this new feature.

Key changes include:

Configuration Updates:
* Added `monitoring` option to `auto_drive` configuration in `config.example.yaml`
* Updated `config/index.ts` to include `AUTO_DRIVE_MONITORING` with a default value

Schema Updates:
* Added `AUTO_DRIVE_MONITORING` to the `autoDriveConfigSchema` in `schema.ts`

Codebase Updates:
* Modified `orchestratorConfig` in `index.ts` and `agent.ts` to include `monitoringEnabled` and update the `monitoring` property accordingly [[1]](diffhunk://#diff-382b3edb1966ece3ac02aa287f74366a97388952eff7d60fe16d48dfd6433fc2R34) [[2]](diffhunk://#diff-382b3edb1966ece3ac02aa287f74366a97388952eff7d60fe16d48dfd6433fc2R44-R46) [[3]](diffhunk://#diff-382b3edb1966ece3ac02aa287f74366a97388952eff7d60fe16d48dfd6433fc2R71-R73) [[4]](diffhunk://#diff-b53615d38e5708e50f68e83b8a6dd0f9a1c3abddf56555240661d0ae643cb5a4L23-R23) [[5]](diffhunk://#diff-b53615d38e5708e50f68e83b8a6dd0f9a1c3abddf56555240661d0ae643cb5a4R32-R34) [[6]](diffhunk://#diff-b53615d38e5708e50f68e83b8a6dd0f9a1c3abddf56555240661d0ae643cb5a4R59-R61) [[7]](diffhunk://#diff-49cc4f0909411e6de89a20d5a97f81c481546b48973288ba70aeb002b0dd4138R15-R29) [[8]](diffhunk://#diff-49cc4f0909411e6de89a20d5a97f81c481546b48973288ba70aeb002b0dd4138L51-R58)