### PR TITLE
Bug: Fix CLI input label wrapping issue

### DIFF
--- a/cli/components/body/InputBox.ts
+++ b/cli/components/body/InputBox.ts
@@ -10,7 +10,7 @@ export const createInputBox = () => {
     border: { type: 'line' },
     style: {
       border: { fg: 'yellow' },
-      focus: { border: { fg: 'white' } },
+      focus: { border: { fg: 'white' } },      
     },
     keys: true,
     vi: true,
@@ -22,6 +22,8 @@ export const createInputBox = () => {
     padding: {
       left: 1,
       right: 1,
+      top: 1
     },
+    wrap: true,    
   });
 };


### PR DESCRIPTION
When the input box label wrapped, the text in the input box wasn't visible.

This pull request includes a small change to the `cli/components/body/InputBox.ts` file. The change adds padding to the top and enables text wrapping in the `createInputBox` function. 

* [`cli/components/body/InputBox.ts`](diffhunk://#diff-aa7e78dd93b547709d2f23bb816ffb94557e40d7a810b4dd0cead3edd0b414a0R25-R27): Added top padding and enabled text wrapping in the `createInputBox` function.