### PR TITLE
Add arxiv search tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@langchain/ollama": "0.2.0",
         "@langchain/openai": "0.4.4",
         "@types/blessed": "^0.1.25",
+        "@types/xml2js": "^0.4.14",
         "agent-twitter-client": "0.0.18",
         "async-mutex": "^0.5.0",
         "axios": "^1.7.9",
@@ -46,6 +47,7 @@
         "sqlite3": "^5.1.7",
         "vectorlite": "^0.2.0",
         "winston": "^3.11.0",
+        "xml2js": "^0.6.2",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.24.1"
     },

--- a/src/agents/tools/arxiv/index.ts
+++ b/src/agents/tools/arxiv/index.ts
@@ -1,0 +1,235 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import axios from 'axios';
+import { parseStringPromise } from 'xml2js';
+import { createLogger } from '../../../utils/logger.js';
+
+const logger = createLogger('arxiv-tool');
+
+interface ArxivEntry {
+  id: string[];
+  title: string[];
+  author: Array<{ name: string[] }>;
+  published: string[];
+  summary: string[];
+}
+
+interface ArxivResponse {
+  feed: {
+    entry?: ArxivEntry[];
+  };
+}
+
+export const createArxivSearchTool = () =>
+  new DynamicStructuredTool({
+    name: 'arxiv_search',
+    description: `
+    Query the arXiv API with advanced filters, including sorting, categories, and author filtering.  
+    USE THIS WHEN:  
+    - The user asks for research papers with specific constraints.
+    OUTPUT: Returns an array of papers with title, authors, publication date, summary, arXiv link, and direct PDF download link.`,
+    schema: z.object({
+      query: z.string().describe(`The search query for retrieving arXiv papers.`),
+      category: z
+        .string()
+        .optional()
+        .describe(
+          `Specify an arXiv category to filter results: 
+        - "astro-ph" (Astrophysics)
+        - "astro-ph.GA" (Astrophysics of Galaxies)
+        - "astro-ph.CO" (Cosmology and Nongalactic Astrophysics)
+        - "astro-ph.EP" (Earth and Planetary Astrophysics)
+        - "astro-ph.HE" (High Energy Astrophysical Phenomena)
+        - "astro-ph.IM" (Instrumentation and Methods for Astrophysics)
+        - "astro-ph.SR" (Solar and Stellar Astrophysics)
+        - "cond-mat" (Condensed Matter)
+        - "cond-mat.dis-nn" (Disordered Systems and Neural Networks)
+        - "cond-mat.mtrl-sci" (Materials Science)
+        - "cond-mat.mes-hall" (Mesoscale and Nanoscale Physics)
+        - "cond-mat.other" (Other Condensed Matter)
+        - "cond-mat.quant-gas" (Quantum Gases)
+        - "cond-mat.soft" (Soft Condensed Matter)
+        - "cond-mat.stat-mech" (Statistical Mechanics)
+        - "cond-mat.str-el" (Strongly Correlated Electrons)
+        - "cond-mat.supr-con" (Superconductivity)
+        - "cs.AI" (Artificial Intelligence)
+        - "cs.AR" (Hardware Architecture)
+        - "cs.CC" (Computational Complexity)
+        - "cs.CE" (Computational Engineering, Finance, and Science)
+        - "cs.CG" (Computational Geometry)
+        - "cs.CL" (Computation and Language)
+        - "cs.CR" (Cryptography and Security)
+        - "cs.CV" (Computer Vision and Pattern Recognition)
+        - "cs.CY" (Computers and Society)
+        - "cs.DB" (Databases)
+        - "cs.DC" (Distributed, Parallel, and Cluster Computing)
+        - "cs.DL" (Digital Libraries)
+        - "cs.DM" (Discrete Mathematics)
+        - "cs.DS" (Data Structures and Algorithms)
+        - "cs.ET" (Emerging Technologies)
+        - "cs.FL" (Formal Languages and Automata Theory)
+        - "cs.GL" (General Literature)
+        - "cs.GR" (Graphics)
+        - "cs.GT" (Computer Science and Game Theory)
+        - "cs.HC" (Human-Computer Interaction)
+        - "cs.IR" (Information Retrieval)
+        - "cs.IT" (Information Theory)
+        - "cs.LG" (Machine Learning)
+        - "cs.LO" (Logic in Computer Science)
+        - "cs.MA" (Multiagent Systems)
+        - "cs.MM" (Multimedia)
+        - "cs.MS" (Mathematical Software)
+        - "cs.NA" (Numerical Analysis)
+        - "cs.NE" (Neural and Evolutionary Computing)
+        - "cs.NI" (Networking and Internet Architecture)
+        - "cs.OH" (Other Computer Science)
+        - "cs.OS" (Operating Systems)
+        - "cs.PF" (Performance)
+        - "cs.PL" (Programming Languages)
+        - "cs.RO" (Robotics)
+        - "cs.SC" (Symbolic Computation)
+        - "cs.SD" (Sound)
+        - "cs.SE" (Software Engineering)
+        - "cs.SI" (Social and Information Networks)
+        - "cs.SY" (Systems and Control)
+        - "econ.EM" (Econometrics)
+        - "eess.AS" (Audio and Speech Processing)
+        - "eess.IV" (Image and Video Processing)
+        - "eess.SP" (Signal Processing)
+        - "math.AC" (Commutative Algebra)
+        - "math.AG" (Algebraic Geometry)
+        - "math.AP" (Analysis of PDEs)
+        - "math.AT" (Algebraic Topology)
+        - "math.CA" (Classical Analysis and ODEs)
+        - "math.CO" (Combinatorics)
+        - "math.CT" (Category Theory)
+        - "math.CV" (Complex Variables)
+        - "math.DG" (Differential Geometry)
+        - "math.DS" (Dynamical Systems)
+        - "math.FA" (Functional Analysis)
+        - "math.GM" (General Mathematics)
+        - "math.GN" (General Topology)
+        - "math.GR" (Group Theory)
+        - "math.GT" (Geometric Topology)
+        - "math.HO" (History and Overview)
+        - "math.IT" (Information Theory)
+        - "math.KT" (K-Theory and Homology)
+        - "math.LO" (Logic)
+        - "math.MG" (Metric Geometry)
+        - "math.NA" (Numerical Analysis)
+        - "math.NT" (Number Theory)
+        - "math.OA" (Operator Algebras)
+        - "math.OC" (Optimization and Control)
+        - "math.PR" (Probability)
+        - "math.QA" (Quantum Algebra)
+        - "math.RA" (Rings and Algebras)
+        - "math.RT" (Representation Theory)
+        - "math.SG" (Symplectic Geometry)
+        - "math.SP" (Spectral Theory)
+        - "math.ST" (Statistics Theory)
+        - "nlin.AO" (Adaptation and Self-Organizing Systems)
+        - "nlin.CD" (Chaotic Dynamics)
+        - "nlin.CG" (Cellular Automata and Lattice Gases)
+        - "nlin.PS" (Pattern Formation and Solitons)
+        - "nlin.SI" (Exactly Solvable and Integrable Systems)
+        - "physics.acc-ph" (Accelerator Physics)
+        - "physics.ao-ph" (Atmospheric and Oceanic Physics)
+        - "physics.app-ph" (Applied Physics)
+        - "physics.atm-clus" (Atomic and Molecular Clusters)
+        - "physics.bio-ph" (Biological Physics)
+        - "physics.chem-ph" (Chemical Physics)
+        - "physics.class-ph" (Classical Physics)
+        - "physics.comp-ph" (Computational Physics)
+        - "physics.data-an" (Data Analysis, Statistics, and Probability)
+        - "physics.flu-dyn" (Fluid Dynamics)
+        - "physics.gen-ph" (General Physics)
+        - "physics.geo-ph" (Geophysics)
+        - "physics.hist-ph" (History and Philosophy of Physics)
+        - "physics.ins-det" (Instrumentation and Detectors)
+        - "physics.med-ph" (Medical Physics)
+        - "physics.optics" (Optics)
+        - "physics.plasm-ph" (Plasma Physics)
+        - "physics.pop-ph" (Popular Physics)
+        - "physics.soc-ph" (Physics and Society)
+        - "physics.space-ph" (Space Physics)
+        - "quant-ph" (Quantum Physics)
+        - "stat.AP" (Applications)
+        - "stat.CO" (Computation)
+        - "stat.ME" (Methodology)
+        - "stat.OT" (Other Statistics)
+        - "stat.TH" (Theory)
+        - Leave empty to search all categories.`,
+        ),
+      author: z.string().optional().describe(`Search for papers by a specific author"`),
+      sortBy: z
+        .enum(['relevance', 'lastUpdatedDate', 'submittedDate'])
+        .default('relevance')
+        .describe(
+          `Sort results by:
+        - "relevance" (default)
+        - "lastUpdatedDate"
+        - "submittedDate"`,
+        ),
+      maxResults: z
+        .number()
+        .default(5)
+        .describe(`Maximum number of papers to retrieve. Default is 5. Max limit is 50.`),
+    }),
+    func: async ({
+      query,
+      category,
+      author,
+      sortBy,
+      maxResults,
+    }: {
+      query: string;
+      category?: string;
+      author?: string;
+      sortBy: string;
+      maxResults: number;
+    }) => {
+      try {
+        const queryTerms = query
+          .trim()
+          .split(/\s+/)
+          .filter(term => term !== 'AND' && Boolean(term));
+
+        const parts = [
+          ...queryTerms,
+          category ? `cat:${category}` : '',
+          author ? `au:${encodeURIComponent(author)}` : '',
+        ].filter(Boolean);
+
+        const searchQuery = parts.join('+AND+');
+        const url = `http://export.arxiv.org/api/query?search_query=${searchQuery}&start=0&max_results=${maxResults}&sortBy=${sortBy}`;
+
+        logger.info(`Fetching papers from arXiv: ${url}`);
+
+        const response = await axios.get(url);
+        const result = (await parseStringPromise(response.data)) as ArxivResponse;
+
+        if (!result.feed || !result.feed.entry) {
+          logger.info('No papers found.');
+          return [];
+        }
+
+        const papers = result.feed.entry.slice(0, maxResults).map((entry: ArxivEntry) => {
+          const paperId = entry.id[0].split('/abs/')[1];
+          return {
+            title: entry.title[0],
+            authors: entry.author.map(a => a.name[0]),
+            published: entry.published[0],
+            summary: entry.summary[0],
+            link: entry.id[0],
+            pdf_link: `https://arxiv.org/pdf/${paperId}.pdf`,
+          };
+        });
+
+        logger.info(`Found ${papers.length} papers.`);
+        return papers;
+      } catch (error) {
+        logger.error('Error fetching data from arXiv API:', error);
+        return [];
+      }
+    },
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,6 +2047,13 @@
   resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
   integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
+"@types/xml2js@^0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.14.tgz#5d462a2a7330345e2309c6b549a183a376de8f9a"
+  integrity sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -5636,6 +5643,11 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@>=0.6.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 scale-ts@^1.6.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/scale-ts/-/scale-ts-1.6.1.tgz#45151e156d6c04792223c39d8e7484ce926445f2"
@@ -6424,6 +6436,19 @@ ws@^8.18.0, ws@^8.8.1:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlcreate@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
This pull request includes the addition of a new tool for querying the arXiv API and updates to the `package.json` dependencies to support this new functionality. The most important changes include the introduction of the `createArxivSearchTool` function and the addition of new dependencies required for XML parsing and logging.

### New Tool for arXiv API Querying:

* [`src/agents/tools/arxiv/index.ts`](diffhunk://#diff-6629c59e103855b4fb6c0bc7614a319bc4b9e68c12e49b83265cce2cd601b014R1-R235): Introduced `createArxivSearchTool`, a new tool for querying the arXiv API with advanced filters, sorting, and author filtering. This tool returns an array of papers with detailed information including title, authors, publication date, summary, arXiv link, and direct PDF download link.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R37): Added `@types/xml2js` and `xml2js` dependencies to support XML parsing required by the new arXiv search tool. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R37) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R50)