### PR TITLE
Fix for Scheduler "Task Already Running" Bug

### DIFF
--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -86,6 +86,8 @@ export type OrchestratorRunner = Readonly<{
   getNextDueTask: () => Task | undefined;
   getTaskQueue: (limit?: number) => ReturnType<TaskQueue['getAllTasks']>;
   getTimeUntilNextTask: () => { nextTask?: Task; msUntilNext: number | null };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  updateTaskStatus: (id: string, status: Task['status'], result?: any) => void;
   deleteTask: (id: string) => void;
 }>;
 
@@ -252,6 +254,10 @@ export const createOrchestratorRunner = async (
 
     getTimeUntilNextTask: () => {
       return taskQueue.getTimeUntilNextTask();
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    updateTaskStatus: (id: string, status: Task['status'], result?: any) => {
+      return taskQueue.updateTaskStatus(id, status, result);
     },
 
     deleteTask: (id: string) => {

--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -86,8 +86,7 @@ export type OrchestratorRunner = Readonly<{
   getNextDueTask: () => Task | undefined;
   getTaskQueue: (limit?: number) => ReturnType<TaskQueue['getAllTasks']>;
   getTimeUntilNextTask: () => { nextTask?: Task; msUntilNext: number | null };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updateTaskStatus: (id: string, status: Task['status'], result?: any) => void;
+  updateTaskStatus: (id: string, status: Task['status'], result?: string) => void;
   deleteTask: (id: string) => void;
 }>;
 
@@ -228,7 +227,7 @@ export const createOrchestratorRunner = async (
         const workflowSummary = `This action finished running at ${new Date().toISOString()}. Action summary: ${summary}`;
         const result = { summary: workflowSummary };
 
-        taskQueue.updateTaskStatus(taskQueue.currentTask?.id || '', 'completed', result);
+        taskQueue.updateTaskStatus(taskQueue.currentTask?.id || '', 'completed', result.summary);
         closeVectorDB(defaultOptions.namespace);
         return result;
       } else {
@@ -255,8 +254,8 @@ export const createOrchestratorRunner = async (
     getTimeUntilNextTask: () => {
       return taskQueue.getTimeUntilNextTask();
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    updateTaskStatus: (id: string, status: Task['status'], result?: any) => {
+
+    updateTaskStatus: (id: string, status: Task['status'], result?: string) => {
       return taskQueue.updateTaskStatus(id, status, result);
     },
 

--- a/src/agents/workflows/orchestrator/scheduler/taskExecutor.ts
+++ b/src/agents/workflows/orchestrator/scheduler/taskExecutor.ts
@@ -12,9 +12,9 @@ export const startTaskExecutor = (
   let running = true;
 
   const executeNextTask = async () => {
-    try {
-      const dueTask = runner.getNextDueTask();
+    const dueTask = runner.getNextDueTask();
 
+    try {
       if (dueTask) {
         logger.info(`Executing scheduled task ${dueTask.id}`, {
           scheduledFor: dueTask.scheduledFor.toISOString(),
@@ -40,6 +40,9 @@ export const startTaskExecutor = (
       logger.error('Error executing scheduled task', {
         error: error instanceof Error ? error.message : String(error),
       });
+      if (error instanceof Error && error.message.includes('Recursion limit') && dueTask) {
+        runner.updateTaskStatus(dueTask.id, 'failed', error.message);
+      }
     }
   };
 

--- a/src/agents/workflows/orchestrator/scheduler/taskExecutor.ts
+++ b/src/agents/workflows/orchestrator/scheduler/taskExecutor.ts
@@ -36,12 +36,16 @@ export const startTaskExecutor = (
 
         broadcastTaskUpdate(namespace);
       }
-    } catch (error: unknown) {
+    } catch (error) {
       logger.error('Error executing scheduled task', {
         error: error instanceof Error ? error.message : String(error),
       });
-      if (error instanceof Error && error.message.includes('Recursion limit') && dueTask) {
-        runner.updateTaskStatus(dueTask.id, 'failed', error.message);
+      if (dueTask) {
+        runner.updateTaskStatus(
+          dueTask.id,
+          'failed',
+          error instanceof Error ? error.message : String(error),
+        );
       }
     }
   };

--- a/src/agents/workflows/orchestrator/scheduler/taskQueue.ts
+++ b/src/agents/workflows/orchestrator/scheduler/taskQueue.ts
@@ -186,8 +186,8 @@ export const createTaskQueue = (namespace: string): TaskQueue => {
 
       return undefined;
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    updateTaskStatus(id: string, status: Task['status'], result?: any): void {
+
+    updateTaskStatus(id: string, status: Task['status'], result?: string): void {
       let task: Task | undefined;
       let isCurrentTask = false;
 

--- a/src/agents/workflows/orchestrator/scheduler/taskQueue.ts
+++ b/src/agents/workflows/orchestrator/scheduler/taskQueue.ts
@@ -140,7 +140,7 @@ export const createTaskQueue = (namespace: string): TaskQueue => {
         logger.info(`Cannot get next task, a task is already running in namespace: ${namespace}`, {
           runningTaskId: currentTask.id,
         });
-        return undefined;
+        return currentTask;
       }
 
       if (scheduledTasks.length === 0) {

--- a/src/agents/workflows/orchestrator/scheduler/types.ts
+++ b/src/agents/workflows/orchestrator/scheduler/types.ts
@@ -23,8 +23,7 @@ export interface TaskQueue {
 
   getNextDueTask: () => Task | undefined;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updateTaskStatus: (id: string, status: Task['status'], result?: any) => void;
+  updateTaskStatus: (id: string, status: Task['status'], result?: string) => void;
 
   deleteTask: (id: string) => void;
 


### PR DESCRIPTION
## Issue Reference
This PR resolves #352  - "Scheduler bug: Cannot get next task, a task is already running"

## Problem
When a task encounters a recursion limit error, it can get stuck in the "processing" state. This causes subsequent attempts to run new tasks to fail with:
```
Cannot get next task, a task is already running in namespace: orchestrator
```

This leaves the orchestrator in an inconsistent state requiring manual intervention to fix.

## Changes

### 1. Improved Error Handling
- Restructured try/catch blocks in the task executor to properly detect and handle recursion limit errors
- Added specific handling for recursion limit errors that automatically marks failed tasks appropriately
```ts
if (error instanceof Error && error.message.includes('Recursion limit') && dueTask) {
  runner.updateTaskStatus(dueTask.id, 'failed', error.message);
}
```

### 2. Task Status Management Enhancements
- Exposed `updateTaskStatus` method in the `OrchestratorRunner` interface to allow external components to update task statuses directly
- Modified `getNextDueTask` to return the currently running task instead of undefined when checking for due tasks
- Improved task result handling by storing the summary string directly rather than a nested object
- Replaced generic `any` result type with specific `string` type for task results
