### PR TITLE
Remove `keep-alive` from agent api header

### DIFF
--- a/src/api/controller/LogsController.ts
+++ b/src/api/controller/LogsController.ts
@@ -11,7 +11,6 @@ export const getLogs = (req: Request, res: Response) => {
   const { namespace } = req.params;
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
 
   res.write(
     `data: ${JSON.stringify({ type: 'connection', message: 'Connected to log stream' })}\n\n`,

--- a/src/api/controller/TaskController.ts
+++ b/src/api/controller/TaskController.ts
@@ -132,7 +132,6 @@ export const getTaskStream = (req: Request, res: Response) => {
 
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
 
   res.write(
     `data: ${JSON.stringify({


### PR DESCRIPTION
This change is necessary since `keep-alive` is forbidden in HTTP/2