### PR TITLE
Add External Workflow Termination Functionality

### DIFF
--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -23,8 +23,7 @@ import { createTaskQueue } from './scheduler/taskQueue.js';
 import { Task, TaskQueue } from './scheduler/types.js';
 import { closeVectorDB } from '../../../services/vectorDb/vectorDBPool.js';
 
-const terminationState = new Map<string, { shouldStop: boolean, reason: string }>();
-
+const terminationState = new Map<string, { shouldStop: boolean; reason: string }>();
 
 const handleConditionalEdge = async (
   state: OrchestratorStateType,
@@ -32,10 +31,11 @@ const handleConditionalEdge = async (
   workflowLogger: Logger,
   namespace: string,
 ) => {
-
   const terminationKey = `${namespace}:terminate`;
   if (terminationState.has(terminationKey)) {
-    workflowLogger.info('Workflow stop requested', { reason: terminationState.get(terminationKey)?.reason });
+    workflowLogger.info('Workflow stop requested', {
+      reason: terminationState.get(terminationKey)?.reason,
+    });
     terminationState.delete(terminationKey);
     return 'finishWorkflow';
   }
@@ -291,7 +291,6 @@ export const createOrchestratorRunner = async (
       } else {
         workflowLogger.info('No current task to terminate');
       }
-      
     },
   };
 };

--- a/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
+++ b/src/agents/workflows/orchestrator/orchestratorWorkflow.ts
@@ -23,11 +23,23 @@ import { createTaskQueue } from './scheduler/taskQueue.js';
 import { Task, TaskQueue } from './scheduler/types.js';
 import { closeVectorDB } from '../../../services/vectorDb/vectorDBPool.js';
 
+const terminationState = new Map<string, { shouldStop: boolean, reason: string }>();
+
+
 const handleConditionalEdge = async (
   state: OrchestratorStateType,
   pruningParameters: PruningParameters,
   workflowLogger: Logger,
+  namespace: string,
 ) => {
+
+  const terminationKey = `${namespace}:terminate`;
+  if (terminationState.has(terminationKey)) {
+    workflowLogger.info('Workflow stop requested', { reason: terminationState.get(terminationKey)?.reason });
+    terminationState.delete(terminationKey);
+    return 'finishWorkflow';
+  }
+
   if (state.workflowControl && state.workflowControl.shouldStop) {
     workflowLogger.info('Workflow stop requested', { reason: state.workflowControl.reason });
     return 'finishWorkflow';
@@ -58,6 +70,7 @@ const createOrchestratorWorkflow = async (
   nodes: Awaited<ReturnType<typeof createNodes>>,
   pruningParameters: PruningParameters,
   workflowLogger: Logger,
+  namespace: string,
 ) => {
   const workflow = new StateGraph(OrchestratorState(pruningParameters))
     .addNode('input', nodes.inputNode)
@@ -66,7 +79,7 @@ const createOrchestratorWorkflow = async (
     .addNode('toolExecution', nodes.toolExecutionNode)
     .addEdge(START, 'input')
     .addConditionalEdges('input', state =>
-      handleConditionalEdge(state, pruningParameters, workflowLogger),
+      handleConditionalEdge(state, pruningParameters, workflowLogger, namespace),
     )
     .addEdge('toolExecution', 'input')
     .addEdge('messageSummary', 'input')
@@ -80,6 +93,9 @@ export type OrchestratorRunner = Readonly<{
     input?: OrchestratorInput,
     options?: { threadId?: string },
   ) => Promise<FinishedWorkflow>;
+
+  // Stop the workflow
+  externalStopWorkflow: (reason?: string) => void;
 
   // Scheduled task management methods
   scheduleTask: (message: string, executeAt: Date) => Task;
@@ -166,12 +182,13 @@ export const createOrchestratorRunner = async (
     nodes,
     runnerConfig.pruningParameters,
     workflowLogger,
+    runnerConfig.namespace,
   );
 
   const memoryStore = new MemorySaver();
   const app = workflow.compile({ checkpointer: memoryStore });
 
-  const namespace = runnerConfig.namespace || 'orchestrator';
+  const namespace = runnerConfig.namespace;
   const taskQueue = createTaskQueue(namespace);
 
   return {
@@ -179,7 +196,7 @@ export const createOrchestratorRunner = async (
       input?: OrchestratorInput,
       options?: { threadId?: string },
     ): Promise<FinishedWorkflow> => {
-      const threadId = `${options?.threadId || 'orchestrator'}-${Date.now()}`;
+      const threadId = `${options?.threadId}-${Date.now()}`;
       workflowLogger.info('Starting orchestrator workflow', { threadId });
 
       const config = {
@@ -261,6 +278,20 @@ export const createOrchestratorRunner = async (
 
     deleteTask: (id: string) => {
       return taskQueue.deleteTask(id);
+    },
+
+    externalStopWorkflow: async (reason?: string): Promise<void> => {
+      workflowLogger.info('Stopping orchestrator workflow', { reason });
+      const currentTask = taskQueue.currentTask;
+      if (currentTask) {
+        taskQueue.updateTaskStatus(currentTask.id, 'failed', `Terminated by user: ${reason}`);
+        workflowLogger.info('Terminated current task', { taskId: currentTask.id });
+        const terminationKey = `${namespace}:terminate`;
+        terminationState.set(terminationKey, { shouldStop: true, reason: reason || 'Unknown' });
+      } else {
+        workflowLogger.info('No current task to terminate');
+      }
+      
     },
   };
 };

--- a/src/api/controller/WorkflowController.ts
+++ b/src/api/controller/WorkflowController.ts
@@ -26,6 +26,24 @@ export const executeWorkflow = asyncHandler(async (req: Request, res: Response) 
   });
 });
 
+export const externalStopWorkflow = asyncHandler(async (req: Request, res: Response) => {
+  const { reason } = req.body;
+  const namespaces = getRegisteredNamespaces();
+  for (const namespace of namespaces) {
+    const runner = orchestratorRunners.get(namespace);
+    if (!runner) {
+      res.status(404).json({ error: `No runner found for namespace: ${namespace}` });
+      return;
+    }
+
+    runner.externalStopWorkflow(reason);
+  }
+
+  res.status(200).json({ status: 'success' });
+});
+
 export const getRegisteredNamespaces = (): string[] => {
   return Array.from(orchestratorRunners.keys());
 };
+
+

--- a/src/api/controller/WorkflowController.ts
+++ b/src/api/controller/WorkflowController.ts
@@ -45,5 +45,3 @@ export const externalStopWorkflow = asyncHandler(async (req: Request, res: Respo
 export const getRegisteredNamespaces = (): string[] => {
   return Array.from(orchestratorRunners.keys());
 };
-
-

--- a/src/api/routes/workflows.ts
+++ b/src/api/routes/workflows.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
-import { executeWorkflow } from '../controller/WorkflowController.js';
+import { executeWorkflow, externalStopWorkflow } from '../controller/WorkflowController.js';
 
 export const createWorkflowsRouter = (): Router => {
   const router = Router();
 
   router.post('/:namespace/run', executeWorkflow);
+  router.post('/stop', externalStopWorkflow);
+
   return router;
 };


### PR DESCRIPTION

### Summary
This PR adds the ability to externally terminate running workflows across all registered orchestrator runners. It implements a new API endpoint and the supporting backend infrastructure to allow for graceful termination of workflows.

### Problem
Prior to this change, once a workflow was started, there was no way to stop it externally before it reached its natural conclusion or encountered an error condition. This limitation made it difficult to handle scenarios where manual intervention was needed or when workflows needed to be terminated based on external events.

### Solution
This PR implements a comprehensive solution for external workflow termination through:

1. A new state management system using a `terminationState` Map to track termination requests by namespace
2. Enhanced conditional edge handling in the orchestrator workflow to check for termination signals
3. A new `externalStopWorkflow` method exposed on the OrchestratorRunner interface
4. An implementation that:
   - Properly logs the termination request
   - Updates the current task status to 'failed' with appropriate reason
   - Sets the termination state for the workflow

5. A new API endpoint (`POST /workflows/stop`) that allows external systems to trigger workflow termination
6. A controller implementation that propagates the termination request to all registered runners


Next PR will about modifying agent decision making on ending the workflow by proposing specific tool attached with a webhook.