### PR TITLE
Add Headless Mode Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Autonomys Agents is an **EXPERIMENTAL** framework for building AI agents. Curren
 5. Run your character:
    - For dev purposes in watch mode: `yarn dev <your-character-name>`
    - For production build and run: `yarn start <your-character-name>`
+6. Run your character in headless mode (without API):
+   - For dev purposes in watch mode: `yarn dev <your-character-name> --headless`
+   - For production build and run: `yarn start <your-character-name> --headless`
 
 ## Interactive Web CLI Interface
 

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -33,9 +33,11 @@ const copyCharacterFile = async (characterName: string): Promise<void> => {
 
 const start = async () => {
   const characterName = process.argv[2];
+  const isHeadless = process.argv[3] === '--headless';
 
   if (!characterName) {
     console.error('Please provide a character name');
+    console.error('Usage: yarn start <character-name> [--headless]');
     process.exit(1);
   }
 
@@ -46,8 +48,13 @@ const start = async () => {
     // Run copy-character script
     await copyCharacterFile(characterName);
 
-    // Run the main program
-    const mainProcess = spawn('node', ['dist/index.js', characterName], { stdio: 'inherit' });
+    const nodeArgs = ['dist/index.js', characterName];
+    if (isHeadless) {
+      nodeArgs.push('--headless');
+    }
+
+    // Run the main program with all arguments
+    const mainProcess = spawn('node', nodeArgs, { stdio: 'inherit' });
 
     mainProcess.on('error', err => {
       console.error('Failed to start main process:', err);

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -113,6 +113,9 @@ export const broadcastTaskUpdate = (namespace: string) => {
 };
 
 export const attachLogger = (logger: Logger, namespace: string) => {
+  if (!config.ENABLE_API) {
+    return logger;
+  }
   const api = createApiServer();
   return api.attachLogger(logger, namespace);
 };
@@ -120,8 +123,8 @@ export const attachLogger = (logger: Logger, namespace: string) => {
 // Helper function
 export const withApiLogger = (namespace: string) => {
   const logger = createLogger(`orchestrator-workflow-${namespace}`);
-  const enhancedLogger = attachLogger(logger, namespace);
 
+  const enhancedLogger = attachLogger(logger, namespace);
   return {
     logger: enhancedLogger,
   };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -20,11 +20,14 @@ try {
 }
 
 export const characterName = process.argv[2];
+
 if (!characterName) {
   console.error('Please provide a character name');
+  console.error('Usage: yarn start <character-name> [--headless]');
   // Force immediate exit of the entire process group
   process.kill(0, 'SIGKILL');
 }
+const isHeadless = process.argv[3] === '--headless';
 
 const characterConfig = loadCharacter(characterName);
 // Load root .env
@@ -163,6 +166,8 @@ export const config = (() => {
           ? process.env.CORS_ALLOWED_ORIGINS.split(',')
           : ['*'],
       },
+
+      ENABLE_API: !isHeadless,
     };
     return configSchema.parse(rawConfig);
   } catch (error) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -156,4 +156,5 @@ export const configSchema = z.object({
   SERPAPI_API_KEY: SERPAPI_API_KEY,
   NODE_ENV: z.enum(['development', 'production', 'test']),
   API_PORT: z.number().int().positive().default(3001),
+  ENABLE_API: z.boolean().default(true),
 });


### PR DESCRIPTION
This PR adds support for running agents in headless mode, allowing operation without the API server.

### Changes
- Added `--headless` flag to disable the API server when running characters
- Updated command parsing in `scripts/start.ts` to handle flags
- Added conditional API initialization based on the headless flag
- Updated configuration schema to include API enablement option
- Added documentation for headless mode usage in README

### Usage
Characters can now be run without the API server using:
```
yarn dev <character-name> --headless
yarn start <character-name> --headless
```

This is useful for environments where the API interface is not needed or for deployment scenarios that only require the core agent functionality. 