### PR TITLE
Add thinking tool

### DIFF
--- a/core/src/agents/tools/thinking/index.ts
+++ b/core/src/agents/tools/thinking/index.ts
@@ -7,9 +7,9 @@ export const createThinkingTool = () =>
     description:
       "Use this tool to reflect on what you've learned so far, analyze your options, and plan your next steps. This is a space for you to organize your thoughts before taking action. It allows you to reason step by step about complex problems, evaluate pros and cons of different approaches, and determine the best course of action based on available information. No external action is taken when you use this tool - it's purely for your internal reasoning process.",
     schema: z.object({
-      thoughts: z.string().describe('Your detailed thought process, analysis, and reasoning'),
+      _thoughts: z.string().describe('Your detailed thought process, analysis, and reasoning'),
     }),
-    func: async ({ thoughts }: { thoughts: string }) => {
+    func: async ({ _thoughts }: { _thoughts: string }) => {
       return {
         success: true,
         message: 'Great job taking a step back and thinking through the problem!',

--- a/core/src/agents/tools/thinking/index.ts
+++ b/core/src/agents/tools/thinking/index.ts
@@ -1,0 +1,18 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+export const createThinkingTool = () =>
+  new DynamicStructuredTool({
+    name: 'thinking',
+    description:
+      "Use this tool to reflect on what you've learned so far, analyze your options, and plan your next steps. This is a space for you to organize your thoughts before taking action. It allows you to reason step by step about complex problems, evaluate pros and cons of different approaches, and determine the best course of action based on available information. No external action is taken when you use this tool - it's purely for your internal reasoning process.",
+    schema: z.object({
+      thoughts: z.string().describe('Your detailed thought process, analysis, and reasoning'),
+    }),
+    func: async ({ thoughts }: { thoughts: string }) => {
+      return {
+        success: true,
+        thoughts,
+      };
+    },
+  });

--- a/core/src/agents/tools/thinking/index.ts
+++ b/core/src/agents/tools/thinking/index.ts
@@ -12,7 +12,7 @@ export const createThinkingTool = () =>
     func: async ({ thoughts }: { thoughts: string }) => {
       return {
         success: true,
-        thoughts,
+        message: 'Great job taking a step back and thinking through the problem!',
       };
     },
   });

--- a/core/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
@@ -21,16 +21,6 @@ export const createInputPrompt = async (character: Character, customInstructions
     
     YOU SHOULD CONTROL THE WORKFLOW WITH THE STOP WORKFLOW TOOL, stop_workflow
 
-    THINKING BEFORE ACTING:
-    - After gathering information but before taking action, use the 'thinking' tool to:
-      1. Reflect on the information gathered so far
-      2. Analyze your options and possible approaches
-      3. Consider potential consequences of different actions
-      4. Plan your strategy and next steps
-      5. Make a decision based on thorough reasoning
-    - This thinking step is critical for making high-quality decisions
-    - Remember to consider how your actions align with your character's goals and values
-
     COMPLETE WORKFLOW WHEN:
     1. You've accomplished your immediate task OR scheduled future tasks for follow-up
     2. You're waiting for anything to complete
@@ -95,10 +85,9 @@ export const createInputPrompt = async (character: Character, customInstructions
       1. Examine what tools you actually have available
       2. Check if you face any stopping conditions (login issues, waiting, tool limitations)
       3. Determine if you can complete tasks with your available tools
-      4. Before executing any action tools, use the 'thinking' tool to reflect on your options and plan your approach
-      5. If you can complete tasks with available tools and haven't done so yet, do it.
-      6. After completing all possible tasks with your tools, use the stop_workflow tool to stop the workflow
-      7. If you find yourself in a loop (repeatedly doing the same thing), use the stop_workflow tool to stop the workflow
+      4. If you can complete tasks with available tools and haven't done so yet, do it.
+      5. After completing all possible tasks with your tools, use the stop_workflow tool to stop the workflow
+      6. If you find yourself in a loop (repeatedly doing the same thing), use the stop_workflow tool to stop the workflow
       `,
     ],
   ]);

--- a/core/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/inputPrompt.ts
@@ -21,6 +21,16 @@ export const createInputPrompt = async (character: Character, customInstructions
     
     YOU SHOULD CONTROL THE WORKFLOW WITH THE STOP WORKFLOW TOOL, stop_workflow
 
+    THINKING BEFORE ACTING:
+    - After gathering information but before taking action, use the 'thinking' tool to:
+      1. Reflect on the information gathered so far
+      2. Analyze your options and possible approaches
+      3. Consider potential consequences of different actions
+      4. Plan your strategy and next steps
+      5. Make a decision based on thorough reasoning
+    - This thinking step is critical for making high-quality decisions
+    - Remember to consider how your actions align with your character's goals and values
+
     COMPLETE WORKFLOW WHEN:
     1. You've accomplished your immediate task OR scheduled future tasks for follow-up
     2. You're waiting for anything to complete
@@ -85,9 +95,10 @@ export const createInputPrompt = async (character: Character, customInstructions
       1. Examine what tools you actually have available
       2. Check if you face any stopping conditions (login issues, waiting, tool limitations)
       3. Determine if you can complete tasks with your available tools
-      4. If you can complete tasks with available tools and haven't done so yet, do it.
-      5. After completing all possible tasks with your tools, use the stop_workflow tool to stop the workflow
-      6. If you find yourself in a loop (repeatedly doing the same thing), use the stop_workflow tool to stop the workflow
+      4. Before executing any action tools, use the 'thinking' tool to reflect on your options and plan your approach
+      5. If you can complete tasks with available tools and haven't done so yet, do it.
+      6. After completing all possible tasks with your tools, use the stop_workflow tool to stop the workflow
+      7. If you find yourself in a loop (repeatedly doing the same thing), use the stop_workflow tool to stop the workflow
       `,
     ],
   ]);

--- a/core/src/agents/workflows/orchestrator/tools.ts
+++ b/core/src/agents/workflows/orchestrator/tools.ts
@@ -3,6 +3,7 @@ import { getVectorDB } from '../../../services/vectorDb/vectorDBPool.js';
 import { createAgentExperienceTools } from '../../tools/agentExperiences/index.js';
 import { createGetCurrentTimeTool } from '../../tools/time/index.js';
 import { createStopWorkflowTool } from '../../tools/stopWorkflow/index.js';
+import { createThinkingTool } from '../../tools/thinking/index.js';
 import { workflowControlState } from './orchestratorWorkflow.js';
 
 export const createDefaultOrchestratorTools = (
@@ -13,6 +14,7 @@ export const createDefaultOrchestratorTools = (
   const agentExperienceTools = createAgentExperienceTools(experienceVectorDb, experienceManager);
   const getCurrentTimeTool = createGetCurrentTimeTool();
   const stopWorkflowTool = createStopWorkflowTool(workflowControlState, namespace);
+  const thinkingTool = createThinkingTool();
 
-  return [...agentExperienceTools, getCurrentTimeTool, stopWorkflowTool];
+  return [...agentExperienceTools, getCurrentTimeTool, stopWorkflowTool, thinkingTool];
 };


### PR DESCRIPTION
OpenAI usage of tools have less internal reflection than Anthropic's usage of tools which leads to less than optimal outcomes at times. This pull request introduces a new `thinking` tool to enhance the decision-making process in the workflow. The most important changes include the creation of the `thinking` tool, its integration into the workflow, and updates to the input prompt instructions to utilize this new tool.

### Creation of the `thinking` tool:
* [`core/src/agents/tools/thinking/index.ts`](diffhunk://#diff-466e27a0aafc028c7fffc56fd9ab62d779f472810e1c3ee783ee496feff282c5R1-R18): Added the `createThinkingTool` function, which defines the `thinking` tool to help users reflect, analyze options, and plan their next steps without taking external actions.

### Integration of the `thinking` tool into the workflow:
* [`core/src/agents/workflows/orchestrator/tools.ts`](diffhunk://#diff-7f775da92b6fb0f991e6b4ded8da45a9d2dc4f5bd5b8e17070d6d6198bbaba3bR6): Imported and included the `thinking` tool in the `createDefaultOrchestratorTools` function, ensuring it is available in the orchestrator's toolset. [[1]](diffhunk://#diff-7f775da92b6fb0f991e6b4ded8da45a9d2dc4f5bd5b8e17070d6d6198bbaba3bR6) [[2]](diffhunk://#diff-7f775da92b6fb0f991e6b4ded8da45a9d2dc4f5bd5b8e17070d6d6198bbaba3bR17-R19)

### Updates to input prompt instructions:
* [`core/src/agents/workflows/orchestrator/nodes/inputPrompt.ts`](diffhunk://#diff-e28a6c564cbfbdc2e013e418cada6489c5ef767ed6230a199bbf3588fbbd2ca2R24-R33): Updated the `createInputPrompt` function to include instructions on using the `thinking` tool before taking action, emphasizing the importance of thorough reasoning and alignment with the character's goals and values. [[1]](diffhunk://#diff-e28a6c564cbfbdc2e013e418cada6489c5ef767ed6230a199bbf3588fbbd2ca2R24-R33) [[2]](diffhunk://#diff-e28a6c564cbfbdc2e013e418cada6489c5ef767ed6230a199bbf3588fbbd2ca2L88-R101)