### PR TITLE
Bug: Update saveLastMemoryCid to handle RPC call failure gracefully

### DIFF
--- a/core/src/blockchain/agentExperience/index.ts
+++ b/core/src/blockchain/agentExperience/index.ts
@@ -65,7 +65,7 @@ export const createExperienceManager = async ({
     return {
       cid,
       previousCid: previousCid || null,
-      evmHash: receipt.hash,
+      evmHash: receipt?.hash || null,
     };
   };
 

--- a/core/src/blockchain/agentExperience/types.ts
+++ b/core/src/blockchain/agentExperience/types.ts
@@ -58,7 +58,7 @@ export type ExperienceManagerOptions = {
 
 export type CidManager = {
   getLastMemoryCid: () => Promise<string>;
-  saveLastMemoryCid: (cid: string) => Promise<ethers.TransactionReceipt>;
+  saveLastMemoryCid: (cid: string) => Promise<ethers.TransactionReceipt | undefined>;
   localHashStatus: { message: string };
 };
 
@@ -66,7 +66,7 @@ export type ExperienceManager = {
   saveExperience: (data: unknown) => Promise<{
     cid: string;
     previousCid: string | null;
-    evmHash: string;
+    evmHash: string | null;
   }>;
   retrieveExperience: (cid: string) => Promise<AgentExperience | AgentExperienceV0>;
   cidManager: CidManager;


### PR DESCRIPTION
There was a remaining edge case of RPC failure that was not handled correctly when saving the last memory CID.

This pull request includes changes to improve error handling and type definitions in the `cidManager` and `ExperienceManager` components of the blockchain agent experience module. The most important changes include updating the `saveLastMemoryCid` function to handle errors more gracefully, modifying the `ExperienceManager` to handle potential undefined values, and updating type definitions accordingly.

Error handling improvements:

* [`core/src/blockchain/agentExperience/cidManager.ts`](diffhunk://#diff-685328590728df7385c5e596c7cb9bc5641a5797a1f392251f656a4c91263cb6L145-R164): Updated the `saveLastMemoryCid` function to handle errors more gracefully by saving the hash locally first and continuing with local storage if the blockchain update fails.

Type definition updates:

* [`core/src/blockchain/agentExperience/index.ts`](diffhunk://#diff-7a4a1e0f8ed41539fc7f4802458c303ca287e9e5c913a217cb75e8ab5bcf4606L68-R68): Modified the `createExperienceManager` function to handle potential undefined values for `receipt.hash` by using optional chaining and defaulting to `null`.
* [`core/src/blockchain/agentExperience/types.ts`](diffhunk://#diff-1a9e884bcfade50cb6e5553cd1f4c84218ce8364d75a9b34e38512eade5f80c6L61-R69): Updated the `saveLastMemoryCid` function in the `CidManager` type to return `Promise<ethers.TransactionReceipt | undefined>` and the `evmHash` in the `ExperienceManager` type to be `string | null`.