### PR TITLE
Bug: RPC could still fail during initialization

### DIFF
--- a/core/src/blockchain/agentExperience/index.ts
+++ b/core/src/blockchain/agentExperience/index.ts
@@ -64,8 +64,8 @@ export const createExperienceManager = async ({
     const receipt = await cidManager.saveLastMemoryCid(cid);
     return {
       cid,
-      previousCid: previousCid || null,
-      evmHash: receipt?.hash || null,
+      previousCid: previousCid,
+      evmHash: receipt?.hash,
     };
   };
 

--- a/core/src/blockchain/agentExperience/types.ts
+++ b/core/src/blockchain/agentExperience/types.ts
@@ -57,7 +57,7 @@ export type ExperienceManagerOptions = {
 };
 
 export type CidManager = {
-  getLastMemoryCid: () => Promise<string>;
+  getLastMemoryCid: () => Promise<string | undefined>;
   saveLastMemoryCid: (cid: string) => Promise<ethers.TransactionReceipt | undefined>;
   localHashStatus: { message: string };
 };
@@ -65,8 +65,8 @@ export type CidManager = {
 export type ExperienceManager = {
   saveExperience: (data: unknown) => Promise<{
     cid: string;
-    previousCid: string | null;
-    evmHash: string | null;
+    previousCid: string | undefined;
+    evmHash: string | undefined;
   }>;
   retrieveExperience: (cid: string) => Promise<AgentExperience | AgentExperienceV0>;
   cidManager: CidManager;


### PR DESCRIPTION
Previously, the code handled the case of a bad RPC on initialization. However, it didn't properly handle a 404 error from a live RPC. This has been hard to test properly, but luckily (😅) we had a node failing with a 404 yesterday so gave the opportunity for more thorough testing. 

An improvement can be made to periodically try to reconnect to the failed RPC rather than going permanently into local mode, but for now this should be sufficient. #383 

## Changes

- Added fallback to local-only storage when RPC provider connection fails
- Updated return types to use `undefined` instead of `null` for better type safety
- Simplified error handling in both `getLastMemoryCid` and `saveLastMemoryCid` methods
- Modified `ExperienceManager` types to match implementation