### PR TITLE
rename autoOS to agent-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Autonomys Agents is an **EXPERIMENTAL** framework for building AI agents. Curren
 
 The agent supports the following command-line arguments:
 
-- **Character Name**: (Required) The first argument specifies which character to run
+- **Character Name**:
   ```bash
-  yarn start my-character --workspace=</path/to/your/project>
+  yarn start my-character
   ```
 
 - **--headless**: (Optional) Run the agent without starting the API server
   ```bash
-  yarn start my-character --workspace=</path/to/your/project> --headless
+  yarn start my-character --headless
   ```
 
 - **--help**: Show available command-line options
@@ -59,7 +59,7 @@ The agent supports the following command-line arguments:
   yarn start --help
   ```
 
- > #### Note: The `--workspace` parameter is required because the runtime needs to locate important directories like characters, certs, and cookies. Always specify the path to your project root where these directories are located.
+> #### Note: The `--workspace` parameter is optional and should only be used when you want to store the characters, certs, and cookies directories in a custom location instead of the default path. Provide the absolute path to the parent directory that will contain these folders.
 
 <!-- ## Docker Deployment simultaneously
 

--- a/agent-package-manager/CHANGELOG.md
+++ b/agent-package-manager/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-04-23
+###Change
+- Rename autoOS to agent-os
+
 ## [0.1.0] - 2025-04-22
 
 ### Added
-- Initial release of autoOS CLI
+- Initial release of agent-os CLI
 - Core commands: `init`, `install`, `publish`, `search`, `tool`, `config`, `clean`
 - Secure credential management using system keychain
 - Auto Drive integration for package storage and retrieval

--- a/agent-package-manager/README.md
+++ b/agent-package-manager/README.md
@@ -28,8 +28,8 @@ agent-os CLI is a command-line interface for managing Autonomys agent tools. It 
 # Using npm
 npm install -g @autonomys/agent-os
 
-# Using yarn
-yarn global add @autonomys/agent-os
+# Using Yarn 2.x
+yarn dlx @autonomys/agent-os
 ```
 
 ### Local Installation

--- a/agent-package-manager/README.md
+++ b/agent-package-manager/README.md
@@ -1,10 +1,10 @@
-# autoOS CLI
+# agent-os CLI
 
 A package manager and toolkit for Autonomys agent tools.
 
 ## Overview
 
-autoOS CLI is a command-line interface for managing Autonomys agent tools. It allows developers to:
+agent-os CLI is a command-line interface for managing Autonomys agent tools. It allows developers to:
 
 - Create new agent projects
 - Install agent tools from the registry
@@ -49,7 +49,7 @@ After installation, you can start using basic commands like `search` and `instal
 To publish tools or perform operations that require blockchain interaction, set up your credentials:
 
 ```bash
-autoOS config --credentials
+agent-os config --credentials
 ```
 
 This interactive wizard will guide you through:
@@ -62,17 +62,17 @@ This interactive wizard will guide you through:
 
 ### Help
 ```bash
-autoOS -h
+agent-os -h
 ```
 
 ### Create a New Agent Project
 
 ```bash
 # Create a basic project
-autoOS init my-agent-project
+agent-os init my-agent-project
 
 # Create a project, install dependencies, and create a character
-autoOS init my-agent-project --install --character=my-character --api
+agent-os init my-agent-project --install --character=my-character --api
 ```
 
 Options:
@@ -84,62 +84,62 @@ Options:
 
 ```bash
 # Install the latest version
-autoOS install <tool-name>
+agent-os install <tool-name>
 
 # Install a specific version
-autoOS install <tool-name> -v <version>
+agent-os install <tool-name> -v <version>
 
 # Install using a Content ID (CID)
-autoOS install <tool-name> --cid <cid>
+agent-os install <tool-name> --cid <cid>
 ```
 
 ### Publish a Tool
 
 ```bash
 # Publish a tool to the registry
-autoOS publish <tool-path>
+agent-os publish <tool-path>
 
 # Upload to Auto Drive without updating the registry
-autoOS publish <tool-path> --no-registry
+agent-os publish <tool-path> --no-registry
 ```
 
 ### Search for Tools
 
 ```bash
 # Search for tools in the registry
-autoOS search <search-term>
+agent-os search <search-term>
 
 # Show detailed information in search results
-autoOS search <search-term> -d
+agent-os search <search-term> -d
 ```
 
 ### Tool Inquiry
 
 ```bash
 # Get information about a tool
-autoOS tool -n <tool-name>
+agent-os tool -n <tool-name>
 
 # Get information about a specific version
-autoOS tool -n <tool-name> -v <version>
+agent-os tool -n <tool-name> -v <version>
 
 # Perform a specific action on a tool
-autoOS tool -n <tool-name> -a <action>
+agent-os tool -n <tool-name> -a <action>
 
 # Example: Get metadata for a specific version
-autoOS tool -n slack-tool -v 1.0.0 -a metadata
+agent-os tool -n slack-tool -v 1.0.0 -a metadata
 ```
 
 ### Configure Settings
 
 ```bash
 # Configure all settings
-autoOS config
+agent-os config
 
 # Configure only credentials
-autoOS config --credentials
+agent-os config --credentials
 
 # General Config
-autoOS config --settings
+agent-os config --settings
 ```
 
 
@@ -147,15 +147,15 @@ autoOS config --settings
 
 ```bash
 # Clean with confirmation
-autoOS clean
+agent-os clean
 
 # Force clean without confirmation
-autoOS clean --force
+agent-os clean --force
 ```
 
 ## Secure Credential Management
 
-autoOS CLI securely manages all your credentials through your system's native keychain. Note that credentials are **only required for publishing tools** - you can freely install and search for tools without setting up credentials.
+agent-os CLI securely manages all your credentials through your system's native keychain. Note that credentials are **only required for publishing tools** - you can freely install and search for tools without setting up credentials.
 
 ### System Keychain Integration
 
@@ -178,7 +178,7 @@ The following credentials are securely managed:
 - Auto Drive encryption password
 - Auto-EVM private key
 
-All credentials are encrypted and accessible only through the autoOS CLI with proper authentication.
+All credentials are encrypted and accessible only through the agent-os CLI with proper authentication.
 
 ## Tool Structure
 
@@ -294,7 +294,7 @@ When you're ready to publish:
 cd weather-tool
 
 # Publish to the registry
-autoOS publish .
+agent-os publish .
 ```
 
 ### Installing and Using Your Tool
@@ -302,7 +302,7 @@ autoOS publish .
 After publishing your tool, you can install it using:
 
 ```bash
-autoOS install weather-tool
+agent-os install weather-tool
 ```
 
 Then, in your agent code, you can import and use the tool:
@@ -327,7 +327,7 @@ const agent = new <Agent-Instantiation>({
 #### "Failed to decrypt credentials" or "No credentials found"
 
 - This error usually appears when trying to publish a tool without configuring credentials
-- Run `autoOS config --credentials` to set up your credentials for publishing
+- Run `agent-os config --credentials` to set up your credentials for publishing
 - Remember that credentials are only required for publishing tools, not for installing or searching
 
 #### API Key Issues

--- a/agent-package-manager/package.json
+++ b/agent-package-manager/package.json
@@ -1,12 +1,10 @@
 {
   "name": "@autonomys/agent-os",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Package manager for Autonomys agent tools",
   "license": "MIT",
   "main": "dist/index.js",
-  "bin": {
-    "autoOS": "./dist/index.js"
-  },
+  "bin": "./dist/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/agent-package-manager/src/commands/clean.ts
+++ b/agent-package-manager/src/commands/clean.ts
@@ -7,7 +7,7 @@ import { CleanOptions, CommandResult } from '../types/index.js';
 import { PACKAGES_DIR } from '../utils/shared/path.js';
 
 const clean = async (options: CleanOptions): Promise<CommandResult> => {
-  const spinner = ora('Cleaning autoOS cache...').start();
+  const spinner = ora('Cleaning agent-os cache...').start();
   spinner.stop();
 
   try {

--- a/agent-package-manager/src/commands/config.ts
+++ b/agent-package-manager/src/commands/config.ts
@@ -3,7 +3,7 @@ import { CommandResult, ConfigOptions } from '../types/index.js';
 import { promptForConfig, promptForCredentials } from '../config/prompts.js';
 
 const config = async (options: ConfigOptions): Promise<CommandResult> => {
-  console.log(chalk.blue.bold('autoOS CLI Configuration\n'));
+  console.log(chalk.blue.bold('agent-os CLI Configuration\n'));
 
   const configureSettings = !options.credentials || options.settings;
   const configureCredentials = !options.settings || options.credentials;
@@ -21,7 +21,7 @@ const config = async (options: ConfigOptions): Promise<CommandResult> => {
       chalk.yellow('• You can store your master password securely in the system keychain'),
     );
     console.log(
-      chalk.yellow('• Alternatively, you can use the AUTOOS_MASTER_PASSWORD environment variable'),
+      chalk.yellow('• Alternatively, you can use the AGENTOS_MASTER_PASSWORD environment variable'),
     );
     console.log('');
 

--- a/agent-package-manager/src/commands/init.ts
+++ b/agent-package-manager/src/commands/init.ts
@@ -127,13 +127,13 @@ const init = async (projectName: string, options: InitOptions): Promise<CommandR
     // Add information about installing tools
     console.log(chalk.green(`\nInstalling agent tools:`));
     console.log(chalk.cyan(`  cd ${projectName}`));
-    console.log(chalk.cyan(`  autoOS install <tool-name>`));
+    console.log(chalk.cyan(`  agent-os install <tool-name>`));
     console.log(chalk.cyan(`  # Tools will be installed to src/tools/ in your project`));
 
     // Suggest flags for next time
     if (!options.install || !options.character || !options.api) {
       console.log(`\n${chalk.yellow('Pro tip:')} Next time, use these flags for a faster setup:`);
-      let command = `  autoOS init ${projectName} --install`;
+      let command = `  agent-os init ${projectName} --install`;
       if (!options.character) command += ' --character=your-character-name';
       if (!options.api) command += ' --api';
       console.log(chalk.cyan(command));

--- a/agent-package-manager/src/commands/install.ts
+++ b/agent-package-manager/src/commands/install.ts
@@ -43,7 +43,7 @@ const install = async (toolName: string, options: InstallOptions): Promise<Comma
       if (error.message.includes('Tool validation failed')) {
         errorMessage = `Invalid tool structure: ${error.message}`;
       } else if (error.message.includes('not found in registry')) {
-        errorMessage = `Tool '${toolName}' not found in registry. Check the name or try 'autoOS search' to find available tools.`;
+        errorMessage = `Tool '${toolName}' not found in registry. Check the name or try 'agent-os search' to find available tools.`;
       } else if (error.message.includes('ENOENT')) {
         errorMessage = `Directory access error: ${error.message}`;
       } else {

--- a/agent-package-manager/src/commands/publish.ts
+++ b/agent-package-manager/src/commands/publish.ts
@@ -17,13 +17,13 @@ const publish = async (toolPath: string, options: PublishOptions): Promise<Comma
       console.log(chalk.yellow('\nPublishing requires credentials to be set up.'));
       console.log(
         chalk.yellow('Please run ') +
-          chalk.cyan('autoOS config --credentials') +
+          chalk.cyan('agent-os config --credentials') +
           chalk.yellow(' to set up your credentials.'),
       );
       return {
         success: false,
         message:
-          'Missing credentials required for publishing. Run "autoOS config --credentials" to set up.',
+          'Missing credentials required for publishing. Run "agent-os config --credentials" to set up.',
       };
     }
 
@@ -50,7 +50,7 @@ const publish = async (toolPath: string, options: PublishOptions): Promise<Comma
       spinner.succeed(`Successfully uploaded ${metadata.name} to DSN (skipped registry update)`);
       console.log(chalk.green(`\nTool uploaded with CID: ${cid}`));
       console.log(chalk.yellow(`\nFor direct installation use:`));
-      console.log(`autoOS install ${metadata.name} --cid ${cid}`);
+      console.log(`agent-os install ${metadata.name} --cid ${cid}`);
     }
 
     return {

--- a/agent-package-manager/src/config/default.ts
+++ b/agent-package-manager/src/config/default.ts
@@ -6,5 +6,5 @@ export const DEFAULT_CONFIG = {
   indexerUrl: '',
 };
 
-export const KEYCHAIN_SERVICE = 'autoOS-cli';
+export const KEYCHAIN_SERVICE = 'agent-os-cli';
 export const KEYCHAIN_ACCOUNT = 'masterPassword';

--- a/agent-package-manager/src/config/prompts.ts
+++ b/agent-package-manager/src/config/prompts.ts
@@ -5,7 +5,7 @@ import { Credentials } from '../types/index.js';
 import { credentialsExist, loadCredentials, saveCredentials } from '../utils/credential/index.js';
 
 const promptForConfig = async () => {
-  console.log(chalk.blue('Configuration setup for autoOS CLI'));
+  console.log(chalk.blue('Configuration setup for agent-os CLI'));
 
   const currentConfig = await loadConfig();
 
@@ -36,7 +36,7 @@ const promptForConfig = async () => {
 };
 
 const promptForCredentials = async (): Promise<Credentials> => {
-  console.log(chalk.blue('Credential setup for autoOS CLI'));
+  console.log(chalk.blue('Credential setup for agent-os CLI'));
 
   const hasExistingCredentials = await credentialsExist();
   let masterPassword: string;

--- a/agent-package-manager/src/index.ts
+++ b/agent-package-manager/src/index.ts
@@ -11,7 +11,7 @@ import { init } from './commands/init.js';
 import { config } from './commands/config.js';
 import { loadConfig } from './config/index.js';
 import { credentialsExist } from './utils/credential/index.js';
-import { ensureAutoOSDir } from './utils/shared/path.js';
+import { ensureAgentOSDir } from './utils/shared/path.js';
 import {
   CleanOptions,
   ConfigOptions,
@@ -33,7 +33,7 @@ const checkMasterPassword = async () => {
 
 const program = new Command();
 
-ensureAutoOSDir()
+ensureAgentOSDir()
   .then(() => {
     return loadConfig();
   })
@@ -71,7 +71,7 @@ ensureAutoOSDir()
     };
 
     program
-      .name('autoOS')
+      .name('agent-os')
       .description('Package manager for Autonomys agent tools')
       .version('0.1.0');
 
@@ -119,7 +119,7 @@ ensureAutoOSDir()
 
     program
       .command('config')
-      .description('Configure the autoOS CLI')
+      .description('Configure the agent-os CLI')
       .option('--credentials', 'Configure only credentials')
       .option('--settings', 'Configure only settings')
       .action(configWrapper);
@@ -139,7 +139,7 @@ ensureAutoOSDir()
     }
   })
   .catch(error => {
-    console.error(chalk.red('Error initializing autoOS CLI:'));
+    console.error(chalk.red('Error initializing agent-os CLI:'));
     console.error(chalk.red(error instanceof Error ? error.message : String(error)));
     process.exit(1);
   });

--- a/agent-package-manager/src/utils/autoDrive/autoDriveClient.ts
+++ b/agent-package-manager/src/utils/autoDrive/autoDriveClient.ts
@@ -22,13 +22,13 @@ const createApiClient = async () => {
     }
 
     throw new Error(
-      "Missing Auto Drive API key. Please run 'autoOS config --credentials' to set up your credentials.",
+      "Missing Auto Drive API key. Please run 'agent-os config --credentials' to set up your credentials.",
     );
   } catch (error) {
     if (error instanceof Error) {
       if (error.message.includes('ENOENT') && error.message.includes('credentials.enc')) {
         throw new Error(
-          "No credentials found. Please run 'autoOS config --credentials' to set up.",
+          "No credentials found. Please run 'agent-os config --credentials' to set up.",
         );
       }
     }

--- a/agent-package-manager/src/utils/commands/install/utils.ts
+++ b/agent-package-manager/src/utils/commands/install/utils.ts
@@ -64,7 +64,7 @@ const resolveVersionInstallation = async (
   const registryToolInfo = await getToolVersionFromRegistry(toolName, version);
   if (!registryToolInfo) {
     throw new Error(
-      `${versionDisplay} of tool '${toolName}' not found in registry. Use 'autoOS list -d' to see available versions.`,
+      `${versionDisplay} of tool '${toolName}' not found in registry. Use 'agent-os list -d' to see available versions.`,
     );
   }
 

--- a/agent-package-manager/src/utils/commands/registry/toolPublish.ts
+++ b/agent-package-manager/src/utils/commands/registry/toolPublish.ts
@@ -110,7 +110,7 @@ const packageAndUploadTool = async (
     } catch (error) {
       if (error instanceof Error && error.message.includes('credentials')) {
         throw new Error(
-          'Publishing requires credentials. Please run "autoOS config --credentials" to set up.',
+          'Publishing requires credentials. Please run "agent-os config --credentials" to set up.',
         );
       }
       throw error;

--- a/agent-package-manager/src/utils/credential/index.ts
+++ b/agent-package-manager/src/utils/credential/index.ts
@@ -53,7 +53,7 @@ const loadCredentials = async (): Promise<Credentials> => {
     const masterPassword = await getFromKeychain();
     if (!masterPassword) {
       throw new Error(
-        'No master password found in keychain. Please run "autoOS config --credentials" to set up.',
+        'No master password found in keychain. Please run "agent-os config --credentials" to set up.',
       );
     }
 
@@ -65,7 +65,7 @@ const loadCredentials = async (): Promise<Credentials> => {
       // Handle file not found error with a clearer message
       if (error instanceof Error && error.message.includes('ENOENT')) {
         throw new Error(
-          'No credentials file found. Please run "autoOS config --credentials" to set up.',
+          'No credentials file found. Please run "agent-os config --credentials" to set up.',
         );
       }
       throw error;

--- a/agent-package-manager/src/utils/shared/path.ts
+++ b/agent-package-manager/src/utils/shared/path.ts
@@ -2,21 +2,21 @@ import path from 'path';
 import fs from 'fs/promises';
 
 const HOME_DIR = process.env.HOME || process.env.USERPROFILE || '';
-const AUTOOS_DIR = path.join(HOME_DIR, '.autoOS');
-const PACKAGES_DIR = path.join(AUTOOS_DIR, 'packages');
+const AGENTOS_DIR = path.join(HOME_DIR, '.agent-os');
+const PACKAGES_DIR = path.join(AGENTOS_DIR, 'packages');
 const DEFAULT_PROJECT_TOOLS_PATH = 'src/tools';
-const REGISTRY_CACHE_PATH = path.join(AUTOOS_DIR, 'registry.json');
-const CONFIG_FILE = path.join(AUTOOS_DIR, 'config.json');
-const CREDENTIALS_FILE = path.join(AUTOOS_DIR, 'credentials.enc');
+const REGISTRY_CACHE_PATH = path.join(AGENTOS_DIR, 'registry.json');
+const CONFIG_FILE = path.join(AGENTOS_DIR, 'config.json');
+const CREDENTIALS_FILE = path.join(AGENTOS_DIR, 'credentials.enc');
 
-const ensureAutoOSDir = async () => {
+const ensureAgentOSDir = async () => {
   try {
     try {
-      await fs.access(AUTOOS_DIR);
+      await fs.access(AGENTOS_DIR);
     } catch {
       // Directory doesn't exist, create it
-      console.log(`Creating directory: ${AUTOOS_DIR}`);
-      const _createAutoOSDir = await fs.mkdir(AUTOOS_DIR, { recursive: true });
+      console.log(`Creating directory: ${AGENTOS_DIR}`);
+      const _createAgentOSDir = await fs.mkdir(AGENTOS_DIR, { recursive: true });
     }
     try {
       await fs.access(PACKAGES_DIR);
@@ -28,7 +28,7 @@ const ensureAutoOSDir = async () => {
 
     return true;
   } catch (error) {
-    console.error('Error creating autoOS directories:', error);
+    console.error('Error creating agent-os directories:', error);
     throw new Error(
       `Failed to create required directories: ${error instanceof Error ? error.message : String(error)}`,
     );
@@ -110,12 +110,12 @@ const getToolInstallDir = async (): Promise<{ installDir: string | undefined }> 
 
 export {
   HOME_DIR,
-  AUTOOS_DIR,
+  AGENTOS_DIR,
   PACKAGES_DIR,
   DEFAULT_PROJECT_TOOLS_PATH,
   REGISTRY_CACHE_PATH,
   CONFIG_FILE,
   CREDENTIALS_FILE,
-  ensureAutoOSDir,
+  ensureAgentOSDir,
   getToolInstallDir,
 };

--- a/agent-package-manager/yarn.lock
+++ b/agent-package-manager/yarn.lock
@@ -39,7 +39,7 @@ __metadata:
     typescript: "npm:^5.0.0"
     typescript-eslint: "npm:^8.27.0"
   bin:
-    autoOS: ./dist/index.js
+    agent-os: ./dist/index.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR is following our discussion about matching package and cli command. Everything is set to `agent-os` now.

V0.1.1 will be published upon PR approval.