### PR TITLE
Fix workspace flag syntax typo and improve Twitter client types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The following examples demonstrate the use of the framework and are available:
 
 To run each example run following command to see the options:
 ```bash
-yarn example <example-name> <character> --workspace=<absolute path to directory that contains characters, .cookies, and certs folders>
+yarn example <example-name> <character> --workspace <absolute path to directory that contains characters, .cookies, and certs folders>
 ```
 
 ## Character System

--- a/agent-package-manager/CHANGELOG.md
+++ b/agent-package-manager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-04-28
+### Fix
+- Typo on --workspace arg hint
+
 ## [0.1.1] - 2025-04-23
 ###Change
 - Rename autoOS to agent-os

--- a/agent-package-manager/src/commands/init.ts
+++ b/agent-package-manager/src/commands/init.ts
@@ -121,7 +121,7 @@ const init = async (projectName: string, options: InitOptions): Promise<CommandR
       if (!options.api) {
         console.log(chalk.cyan(`  yarn generate-certs`));
       }
-      console.log(chalk.cyan(`  yarn start ${options.character} --workspace=/path/to/workspace`));
+      console.log(chalk.cyan(`  yarn start ${options.character} --workspace /path/to/workspace`));
     }
 
     // Add information about installing tools

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `@autonomys/agent-core` package will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2025-04-28
+
+### Fixed
+
+- Importing an exporting of some types from 'agent-twitter-client'
+
 ## [0.2.3] - 2025-04-25
 
 ### Added

--- a/core/README.md
+++ b/core/README.md
@@ -118,9 +118,9 @@ When running your agent implementation, these arguments are automatically parsed
   npx tsx your-script.ts my-character-name --headless
   ```
 
-- **--workspace=PATH**: Specify a custom workspace root directory where the `characters` folder exists
+- **--workspace PATH**: Specify a custom workspace root directory where the `characters` folder exists
   ```bash
-  npx tsx your-script.ts my-character-name --workspace=/path/to/your/project
+  npx tsx your-script.ts my-character-name --workspace /path/to/your/project
   ```
 
 ### Example Script
@@ -148,7 +148,7 @@ Then run it with:
 ```bash
 npx tsx index.ts my-character-name
 npx tsx index.ts my-character-name --headless
-npx tsx index.ts my-character-name --workspace=/path/to/workspace
+npx tsx index.ts my-character-name --workspace /path/to/workspace
 ```
 
 ## Example Implementation

--- a/core/src/agents/tools/twitter/types.ts
+++ b/core/src/agents/tools/twitter/types.ts
@@ -1,5 +1,5 @@
-import { Profile, Scraper, Tweet } from 'agent-twitter-client';
-export { Tweet, Profile, Scraper } from 'agent-twitter-client';
+import { type Profile, Scraper, type Tweet } from 'agent-twitter-client';
+export { type Tweet, type Profile, Scraper } from 'agent-twitter-client';
 
 export interface TwitterApi {
   scraper: Scraper;

--- a/core/src/config/config.ts
+++ b/core/src/config/config.ts
@@ -72,7 +72,7 @@ export const getConfig = async (options?: ConfigOptions): Promise<ConfigInstance
 
   if (!characterName) {
     console.error('Please provide a character name');
-    console.error('Usage: yarn dev:agent <character-name> [--headless] [--workspace=path]');
+    console.error('Usage: yarn dev:agent <character-name> [--headless] [--workspace path]');
     process.exit(1);
   }
 

--- a/examples/multiPersonality/README.md
+++ b/examples/multiPersonality/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to orchestrate an LLM-powered agents with differen
 ## Usage
 
 1. Ensure all dependencies are installed with `yarn install`.
-2. Run the example by calling `yarn example:multi-personality <your-character-name> --workspace=<absolute path to directory that contains characters, .cookies, and certs folders>`.
+2. Run the example by calling `yarn example:multi-personality <your-character-name> --workspace <absolute path to directory that contains characters, .cookies, and certs folders>`.
 3. Monitor the logs to see how the agent interacts, updates its workflow, and schedules subsequent interactions.
 
 This example serves as a template for integrating a social media management agent managed by a more responsible orchestration agent, and can be extended to support more complex scenarios and integrations.

--- a/examples/twitterAgent/README.md
+++ b/examples/twitterAgent/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to orchestrate an LLM-powered agent designed to si
 ## Usage
 
 1. Ensure all dependencies are installed with `yarn install`.
-2. Run the example by calling `yarn example twitter <character> --workspace=<absolute path to directory that contains characters, .cookies, and certs folders>`.
+2. Run the example by calling `yarn example twitter <character> --workspace <absolute path to directory that contains characters, .cookies, and certs folders>`.
 3. Monitor the logs to see how the agent interacts, updates its workflow, and schedules subsequent interactions.
 
 This example serves as a template for integrating a social media management agent powered by LLM orchestration, and can be extended to support more complex scenarios and integrations.

--- a/examples/web3Agent/README.md
+++ b/examples/web3Agent/README.md
@@ -14,7 +14,7 @@ This is a simple example demonstrating how to create an autonomous agent capable
 To run this example:
 
 ```bash
-yarn examples/web3Agent <your-character-name> --workspace=<absolute path to directory that contains characters, .cookies, and certs folders>`
+yarn examples/web3Agent <your-character-name> --workspace <absolute path to directory that contains characters, .cookies, and certs folders>`
 ```
 
 ## How It Works


### PR DESCRIPTION

### Description

This PR includes two main improvements:

1. Command-line argument syntax standardization:
   - Updated the `--workspace` flag syntax across all documentation and code files to use space separator instead of equals sign
   - Changed from `--workspace=/path/to/workspace` to `--workspace /path/to/workspace`
   - This change makes the syntax more consistent with common CLI patterns
   - Updated in README files, example documentation, and code output messages

2. Twitter client type improvements:
   - Enhanced type exports from 'agent-twitter-client'
   - Added explicit type annotations using the `type` keyword for better type safety
   - Affects Tweet and Profile type imports/exports