### PR TITLE
(feature): Add Update Command to agent-os

### DIFF
--- a/agent-package-manager/CHANGELOG.md
+++ b/agent-package-manager/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-04-30
+
+### Added
+- update command to check for newest version and upgrade the agent-os
+
 ## [0.1.2] - 2025-04-28
 
 ### Fix

--- a/agent-package-manager/package.json
+++ b/agent-package-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autonomys/agent-os",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Package manager for Autonomys agent tools",
   "license": "MIT",
   "main": "dist/index.js",

--- a/agent-package-manager/src/commands/init.ts
+++ b/agent-package-manager/src/commands/init.ts
@@ -4,13 +4,14 @@ import fs from 'fs/promises';
 import path from 'path';
 import { CommandResult, InitOptions } from '../types/index.js';
 import { customizeTemplate, downloadTemplate, runCommand } from '../utils/commands/init/index.js';
+import checkForUpdates from '../utils/update/index.js';
 
 /**
  * Initialize a new agent project
  */
 const init = async (projectName: string, options: InitOptions): Promise<CommandResult> => {
   const spinner = ora(`Creating new agent project: ${projectName}...`).start();
-
+  const _checkForUpdates = await checkForUpdates();
   try {
     // Determine project path
     const projectPath = path.resolve(process.cwd(), projectName);

--- a/agent-package-manager/src/commands/install.ts
+++ b/agent-package-manager/src/commands/install.ts
@@ -7,7 +7,6 @@ import { getToolInstallDir } from '../utils/shared/path.js';
 import { resolveToolInfo } from '../utils/commands/install/utils.js';
 import checkForUpdates from '../utils/update/index.js';
 
-
 const install = async (toolName: string, options: InstallOptions): Promise<CommandResult> => {
   const spinner = ora(`Installing ${toolName}...`).start();
   const _checkForUpdates = await checkForUpdates();

--- a/agent-package-manager/src/commands/install.ts
+++ b/agent-package-manager/src/commands/install.ts
@@ -5,9 +5,12 @@ import { InstallOptions } from '../types/index.js';
 import { performToolInstallation } from '../utils/commands/install/toolInstall.js';
 import { getToolInstallDir } from '../utils/shared/path.js';
 import { resolveToolInfo } from '../utils/commands/install/utils.js';
+import checkForUpdates from '../utils/update/index.js';
+
 
 const install = async (toolName: string, options: InstallOptions): Promise<CommandResult> => {
   const spinner = ora(`Installing ${toolName}...`).start();
+  const _checkForUpdates = await checkForUpdates();
   try {
     const { installDir } = await getToolInstallDir();
     if (!installDir) {

--- a/agent-package-manager/src/commands/publish.ts
+++ b/agent-package-manager/src/commands/publish.ts
@@ -5,10 +5,11 @@ import { updateRegistry } from '../utils/commands/registry/updateRegistry.js';
 import { validateToolStructure } from '../utils/validation.js';
 import { packageAndUploadTool } from '../utils/commands/registry/toolPublish.js';
 import { credentialsExist } from '../utils/credential/index.js';
+import checkForUpdates from '../utils/update/index.js';
 
 const publish = async (toolPath: string, options: PublishOptions): Promise<CommandResult> => {
   const spinner = ora(`Publishing tool from ${toolPath}...`).start();
-
+  const _checkForUpdates = await checkForUpdates();
   try {
     // Early check for credentials
     const hasCredentials = await credentialsExist();

--- a/agent-package-manager/src/commands/tool.ts
+++ b/agent-package-manager/src/commands/tool.ts
@@ -2,10 +2,11 @@ import chalk from 'chalk';
 import { getToolMetadata } from '../utils/commands/registry/toolInquiry.js';
 import { getToolVersions } from '../utils/blockchain/contractClient.js';
 import { ToolCommandParams } from '../types/index.js';
+import checkForUpdates from '../utils/update/index.js';
 
 const tool = async (params: ToolCommandParams): Promise<void> => {
   const { name, version, action } = params;
-
+  const _checkForUpdates = await checkForUpdates();
   if (version && action === 'metadata') {
     const metadata = await getToolMetadata(name, version);
     if (metadata) {

--- a/agent-package-manager/src/commands/update.ts
+++ b/agent-package-manager/src/commands/update.ts
@@ -1,55 +1,10 @@
-import chalk from 'chalk';
-import ora from 'ora';
 import { UpdateOptions } from '../types/index.js';
-import { execSync } from 'child_process';
-import { getNpmPackageInfo } from '../utils/npm/index.js';
+import checkForUpdates from '../utils/update/index.js';
 
 /**
  * Check for updates to the agent-os CLI
  * @param options Update command options
  */
 export const update = async (options: UpdateOptions): Promise<void> => {
-  const spinner = ora('Checking for updates...').start();
-  
-  try {
-    const packageName = '@autonomys/agent-os';
-    const currentVersion = execSync('agent-os -V', { encoding: 'utf-8' }).trim();
-    
-    // Fetch latest version from npm
-    const npmInfo = await getNpmPackageInfo(packageName);
-    const latestVersion = npmInfo.version;
-    
-    if (latestVersion === currentVersion) {
-      spinner.succeed(chalk.green(`You are already using the latest version (${currentVersion}) of agent-os!`));
-      return;
-    }
-
-    spinner.succeed(
-      chalk.yellow(`Update available! ${chalk.blue(currentVersion)} → ${chalk.green(latestVersion)}`)
-    );
-    
-    console.log('\nTo update, run:');
-    console.log(chalk.cyan(`npm install -g ${packageName}@latest`));
-    console.log(chalk.cyan(`yarn dlx ${packageName}@latest`));
-    
-    if (options.auto) {
-      spinner.start('Updating automatically...');
-      try {
-        const updateCommand = `yarn dlx -g ${packageName}@latest`;
-        execSync(updateCommand, { stdio: 'inherit' });
-        spinner.succeed(chalk.green('Successfully updated to the latest version!'));
-      } catch (error) {
-        spinner.fail(chalk.red('Failed to update automatically.'));
-        console.error(chalk.red('Please update manually using the command above.'));
-        if (error instanceof Error) {
-          console.error(chalk.grey(error.message));
-        }
-      }
-    }
-  } catch (error) {
-    spinner.fail(chalk.red('Failed to check for updates.'));
-    if (error instanceof Error) {
-      console.error(chalk.red(error.message));
-    }
-  }
-}; 
+  const _checkForUpdates = await checkForUpdates(options);
+};

--- a/agent-package-manager/src/commands/update.ts
+++ b/agent-package-manager/src/commands/update.ts
@@ -1,0 +1,55 @@
+import chalk from 'chalk';
+import ora from 'ora';
+import { UpdateOptions } from '../types/index.js';
+import { execSync } from 'child_process';
+import { getNpmPackageInfo } from '../utils/npm/index.js';
+
+/**
+ * Check for updates to the agent-os CLI
+ * @param options Update command options
+ */
+export const update = async (options: UpdateOptions): Promise<void> => {
+  const spinner = ora('Checking for updates...').start();
+  
+  try {
+    const packageName = '@autonomys/agent-os';
+    const currentVersion = execSync('agent-os -V', { encoding: 'utf-8' }).trim();
+    
+    // Fetch latest version from npm
+    const npmInfo = await getNpmPackageInfo(packageName);
+    const latestVersion = npmInfo.version;
+    
+    if (latestVersion === currentVersion) {
+      spinner.succeed(chalk.green(`You are already using the latest version (${currentVersion}) of agent-os!`));
+      return;
+    }
+
+    spinner.succeed(
+      chalk.yellow(`Update available! ${chalk.blue(currentVersion)} → ${chalk.green(latestVersion)}`)
+    );
+    
+    console.log('\nTo update, run:');
+    console.log(chalk.cyan(`npm install -g ${packageName}@latest`));
+    console.log(chalk.cyan(`yarn dlx ${packageName}@latest`));
+    
+    if (options.auto) {
+      spinner.start('Updating automatically...');
+      try {
+        const updateCommand = `yarn dlx -g ${packageName}@latest`;
+        execSync(updateCommand, { stdio: 'inherit' });
+        spinner.succeed(chalk.green('Successfully updated to the latest version!'));
+      } catch (error) {
+        spinner.fail(chalk.red('Failed to update automatically.'));
+        console.error(chalk.red('Please update manually using the command above.'));
+        if (error instanceof Error) {
+          console.error(chalk.grey(error.message));
+        }
+      }
+    }
+  } catch (error) {
+    spinner.fail(chalk.red('Failed to check for updates.'));
+    if (error instanceof Error) {
+      console.error(chalk.red(error.message));
+    }
+  }
+}; 

--- a/agent-package-manager/src/index.ts
+++ b/agent-package-manager/src/index.ts
@@ -79,7 +79,7 @@ ensureAgentOSDir()
     program
       .name('agent-os')
       .description('Package manager for Autonomys agent tools')
-      .version('0.1.0');
+      .version('0.1.3');
 
     program
       .command('init')

--- a/agent-package-manager/src/index.ts
+++ b/agent-package-manager/src/index.ts
@@ -20,7 +20,7 @@ import {
   InstallOptions,
   PublishOptions,
   ToolCommandParams,
-  UpdateOptions
+  UpdateOptions,
 } from './types/index.js';
 
 const checkMasterPassword = async () => {

--- a/agent-package-manager/src/index.ts
+++ b/agent-package-manager/src/index.ts
@@ -9,6 +9,7 @@ import { clean } from './commands/clean.js';
 import { tool } from './commands/tool.js';
 import { init } from './commands/init.js';
 import { config } from './commands/config.js';
+import { update } from './commands/update.js';
 import { loadConfig } from './config/index.js';
 import { credentialsExist } from './utils/credential/index.js';
 import { ensureAgentOSDir } from './utils/shared/path.js';
@@ -19,6 +20,7 @@ import {
   InstallOptions,
   PublishOptions,
   ToolCommandParams,
+  UpdateOptions
 } from './types/index.js';
 
 const checkMasterPassword = async () => {
@@ -68,6 +70,10 @@ ensureAgentOSDir()
 
     const toolWrapper = async (options: ToolCommandParams) => {
       await tool(options);
+    };
+
+    const updateWrapper = async (options: UpdateOptions = {}) => {
+      await update(options);
     };
 
     program
@@ -129,6 +135,12 @@ ensureAgentOSDir()
       .description('Clean cached packages and temporary files')
       .option('--force', 'Force clean without confirmation')
       .action(cleanWrapper);
+
+    program
+      .command('update')
+      .description('Check for updates to the agent-os CLI')
+      .option('--auto', 'Automatically install the latest version if available')
+      .action(updateWrapper);
 
     program.showHelpAfterError();
 

--- a/agent-package-manager/src/types/index.ts
+++ b/agent-package-manager/src/types/index.ts
@@ -12,6 +12,10 @@ export interface InitOptions {
   api?: boolean;
 }
 
+export interface UpdateOptions {
+  auto?: boolean;
+}
+
 export interface ToolInstallInfo {
   name: string;
   cid: string;

--- a/agent-package-manager/src/utils/npm/index.ts
+++ b/agent-package-manager/src/utils/npm/index.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+
+interface NpmPackageInfo {
+  name: string;
+  version: string;
+  description: string;
+  homepage: string;
+  license: string;
+  [key: string]: any;
+}
+
+/**
+ * Fetches package information from npm registry
+ * @param packageName The npm package name
+ * @returns Package information
+ */
+export const getNpmPackageInfo = async (packageName: string): Promise<NpmPackageInfo> => {
+  try {
+    const response = await axios.get(`https://registry.npmjs.org/${packageName}`);
+    
+    if (response.status !== 200) {
+      throw new Error(`Failed to fetch package info: ${response.statusText}`);
+    }
+    
+    const data = response.data;
+    const latestVersion = data['dist-tags']?.latest;
+    
+    if (!latestVersion) {
+      throw new Error('Could not determine latest version');
+    }
+    
+    const versionInfo = data.versions[latestVersion];
+    
+    return {
+      name: data.name,
+      version: latestVersion,
+      description: versionInfo.description || data.description || '',
+      homepage: versionInfo.homepage || data.homepage || '',
+      license: versionInfo.license || data.license || '',
+      ...versionInfo
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw new Error(`Failed to fetch package info: ${error.message}`);
+    }
+    throw error;
+  }
+}; 

--- a/agent-package-manager/src/utils/npm/index.ts
+++ b/agent-package-manager/src/utils/npm/index.ts
@@ -6,7 +6,6 @@ interface NpmPackageInfo {
   description: string;
   homepage: string;
   license: string;
-  [key: string]: any;
 }
 
 /**
@@ -17,27 +16,27 @@ interface NpmPackageInfo {
 export const getNpmPackageInfo = async (packageName: string): Promise<NpmPackageInfo> => {
   try {
     const response = await axios.get(`https://registry.npmjs.org/${packageName}`);
-    
+
     if (response.status !== 200) {
       throw new Error(`Failed to fetch package info: ${response.statusText}`);
     }
-    
+
     const data = response.data;
     const latestVersion = data['dist-tags']?.latest;
-    
+
     if (!latestVersion) {
       throw new Error('Could not determine latest version');
     }
-    
+
     const versionInfo = data.versions[latestVersion];
-    
+
     return {
       name: data.name,
       version: latestVersion,
       description: versionInfo.description || data.description || '',
       homepage: versionInfo.homepage || data.homepage || '',
       license: versionInfo.license || data.license || '',
-      ...versionInfo
+      ...versionInfo,
     };
   } catch (error) {
     if (axios.isAxiosError(error)) {
@@ -45,4 +44,4 @@ export const getNpmPackageInfo = async (packageName: string): Promise<NpmPackage
     }
     throw error;
   }
-}; 
+};

--- a/agent-package-manager/src/utils/update/index.ts
+++ b/agent-package-manager/src/utils/update/index.ts
@@ -1,0 +1,60 @@
+import chalk from 'chalk';
+import { execSync } from 'child_process';
+import { getNpmPackageInfo } from '../npm/index.js';
+import ora from 'ora';
+import { UpdateOptions } from '../../types/index.js';
+
+const checkForUpdates = async (options: UpdateOptions = {}) => {
+  const spinner = ora('Checking for updates...').start();
+  try {
+    const packageName = '@autonomys/agent-os';
+    const currentVersion = execSync('agent-os -V', { encoding: 'utf-8' }).trim();
+
+    const npmInfo = await getNpmPackageInfo(packageName);
+    const latestVersion = npmInfo.version;
+
+    if (latestVersion === currentVersion) {
+      spinner.succeed(
+        chalk.green(`You are already using the latest version (${currentVersion}) of agent-os!`),
+      );
+      return;
+    }
+
+    spinner.succeed(
+      chalk.yellow(
+        `Update available! ${chalk.blue(currentVersion)} → ${chalk.green(latestVersion)}`,
+      ),
+    );
+
+    if (options.auto) {
+      spinner.start('Updating automatically...');
+      try {
+        const updateCommand = `yarn dlx -g ${packageName}@latest`;
+        execSync(updateCommand, { stdio: 'inherit' });
+        spinner.succeed(chalk.green('Successfully updated to the latest version!'));
+      } catch (error) {
+        spinner.fail(chalk.red('Failed to update automatically.'));
+        console.error(chalk.red('Please update manually using the commands below.'));
+        if (error instanceof Error) {
+          console.error(chalk.grey(error.message));
+        }
+        // Display manual update instructions
+        console.log('\nTo update, run:');
+        console.log(chalk.cyan(`npm install -g ${packageName}@latest`));
+        console.log(chalk.cyan(`yarn dlx ${packageName}@latest`));
+      }
+    } else {
+      // Display manual update instructions
+      console.log('\nTo update, run:');
+      console.log(chalk.cyan(`npm install -g ${packageName}@latest`));
+      console.log(chalk.cyan(`yarn dlx ${packageName}@latest`));
+    }
+  } catch (error) {
+    spinner.fail(chalk.red('Failed to check for updates.'));
+    if (error instanceof Error) {
+      console.error(chalk.red(error.message));
+    }
+  }
+};
+
+export default checkForUpdates;


### PR DESCRIPTION
## Summary
This PR adds a new `update` command to the agent-os CLI, allowing users to check for and install updates to the package.

## Changes
- Added new `update` command to check for newest version and upgrade the agent-os
- Added update checking functionality to existing commands (init, install, publish, tool)
- Created utility functions to check npm package information
- Bumped version from 0.1.2 to 0.1.3
- Updated CHANGELOG.md with new version information

## New Functionality
- `agent-os update` - Checks for updates to the CLI
- `agent-os update --auto` - Automatically installs the latest version if available
- Added update check to existing commands to notify users when a new version is available

## Implementation Details
- The update functionality uses axios to query the npm registry
- Update checks display current version vs latest version if an update is available
- Provides instructions for manual update when auto-update is not selected