### PR TITLE
Streamlining and Simplifying LLM Configuration (Part 2)

### DIFF
--- a/characters/character.example/config/.env.example
+++ b/characters/character.example/config/.env.example
@@ -5,7 +5,7 @@ TWITTER_PASSWORD=<twitter_password>
 # LLM Configuration
 OPENAI_API_KEY=<openai_api_key>
 ANTHROPIC_API_KEY=<anthropic_api_key>
-LLAMA_API_URL=<llama_api_url>
+OLLAMA_API_URL=<llama_api_url>
 DEEPSEEK_URL=<deepseek_api_url>
 DEEPSEEK_API_KEY=<deepseek_api_key>
 GROQ_API_KEY=<groq_api_key>

--- a/core/src/agents/chat/config.ts
+++ b/core/src/agents/chat/config.ts
@@ -10,6 +10,5 @@ const defaultModelConfig: LLMConfiguration = {
 export const createChatNodeConfig = (options: ChatNodeConfig): ChatNodeConfig => {
   const modelConfig = options.modelConfig ?? defaultModelConfig;
   const tools = options.tools;
-  const llmConfig = options.llmConfig;
-  return { modelConfig, tools, llmConfig };
+  return { modelConfig, tools };
 };

--- a/core/src/agents/chat/nodes.ts
+++ b/core/src/agents/chat/nodes.ts
@@ -10,7 +10,6 @@ export const createNodes = (config: ChatNodeConfig) => {
   const inputNode = createInputNode({
     modelConfig: config.modelConfig,
     tools: config.tools,
-    llmConfig: config.llmConfig,
   });
 
   return {

--- a/core/src/agents/chat/nodes/input.ts
+++ b/core/src/agents/chat/nodes/input.ts
@@ -1,4 +1,4 @@
-import { LLMConfiguration, LLMFactory, LLMFactoryConfig } from '../../../services/index.js';
+import { LLMConfiguration, LLMFactory } from '../../../services/index.js';
 import { ChatState } from '../state.js';
 import { promptTemplate } from './prompt.js';
 import { createLogger } from '../../../utils/logger.js';
@@ -9,15 +9,13 @@ const logger = createLogger('chat-input');
 const createInputNode = ({
   modelConfig,
   tools,
-  llmConfig,
 }: {
   modelConfig: LLMConfiguration;
   tools: DynamicStructuredTool[];
-  llmConfig: LLMFactoryConfig;
 }): InputNodeFunction => {
   const runNode = async (state: typeof ChatState.State) => {
     const prompt = await promptTemplate.invoke(state);
-    const llmModel = LLMFactory.createModel(modelConfig, llmConfig).bindTools(tools);
+    const llmModel = LLMFactory.createModel(modelConfig).bindTools(tools);
     const model = await llmModel.invoke(prompt);
     logger.info('Model response', { model });
     const toolCalls = model.tool_calls;

--- a/core/src/agents/chat/tools.ts
+++ b/core/src/agents/chat/tools.ts
@@ -4,10 +4,7 @@ import { createAgentExperienceTools } from '../tools/agentExperiences/index.js';
 import { createGetCurrentTimeTool } from '../tools/time/index.js';
 import { createSchedulerAddTaskTool } from '../tools/scheduler/index.js';
 
-export const createDefaultChatTools = (
-  dataPath: string,
-  experienceManager?: ExperienceManager,
-) => {
+export const createDefaultChatTools = (dataPath: string, experienceManager?: ExperienceManager) => {
   const experienceVectorDb = getVectorDB('experiences', dataPath);
   const agentExperienceTools = createAgentExperienceTools(experienceVectorDb, experienceManager);
   const getCurrentTimeTool = createGetCurrentTimeTool();

--- a/core/src/agents/chat/tools.ts
+++ b/core/src/agents/chat/tools.ts
@@ -2,15 +2,13 @@ import { ExperienceManager } from '../../blockchain/agentExperience/types.js';
 import { getVectorDB } from '../../services/vectorDb/vectorDBPool.js';
 import { createAgentExperienceTools } from '../tools/agentExperiences/index.js';
 import { createGetCurrentTimeTool } from '../tools/time/index.js';
-import { LLMFactoryConfig } from '../../services/llm/types.js';
 import { createSchedulerAddTaskTool } from '../tools/scheduler/index.js';
 
 export const createDefaultChatTools = (
-  llmConfig: LLMFactoryConfig,
   dataPath: string,
   experienceManager?: ExperienceManager,
 ) => {
-  const experienceVectorDb = getVectorDB('experiences', llmConfig, dataPath);
+  const experienceVectorDb = getVectorDB('experiences', dataPath);
   const agentExperienceTools = createAgentExperienceTools(experienceVectorDb, experienceManager);
   const getCurrentTimeTool = createGetCurrentTimeTool();
   const schedulerAddTaskTool = createSchedulerAddTaskTool();

--- a/core/src/agents/chat/types.ts
+++ b/core/src/agents/chat/types.ts
@@ -1,4 +1,3 @@
-import { LLMFactoryConfig } from '../../services/llm/types.js';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { LLMConfiguration } from '../../services/llm/types.js';
 import { ChatState } from './state.js';
@@ -15,7 +14,6 @@ export type InputNodeFunction = (state: typeof ChatState.State) => Promise<{
 export type ChatNodeConfig = {
   tools: DynamicStructuredTool[];
   modelConfig: LLMConfiguration;
-  llmConfig: LLMFactoryConfig;
 };
 
 export type ChatWorkflow = ReturnType<typeof createChatWorkflow>;

--- a/core/src/agents/chat/workflow.ts
+++ b/core/src/agents/chat/workflow.ts
@@ -5,11 +5,10 @@ import { ChatNodeConfig } from './types.js';
 import { createChatNodeConfig } from './config.js';
 
 export const createChatWorkflow = async (options: ChatNodeConfig) => {
-  const { modelConfig, tools, llmConfig } = createChatNodeConfig(options);
+  const { modelConfig, tools } = createChatNodeConfig(options);
   const { inputNode, executor } = createNodes({
     modelConfig,
     tools,
-    llmConfig,
   });
 
   /**

--- a/core/src/agents/workflows/github/githubAgent.ts
+++ b/core/src/agents/workflows/github/githubAgent.ts
@@ -13,7 +13,6 @@ import {
   createApiConfig,
   createCharacterDataPathConfig,
   createExperienceConfig,
-  createLLMConfig,
   createModelConfigurations,
   createMonitoringConfig,
   createPruningParameters,
@@ -54,7 +53,6 @@ const createGithubAgentConfig = async (
   const pruningParameters = createPruningParameters(options);
   const characterDataPathConfig = createCharacterDataPathConfig(options);
   const apiConfig = createApiConfig(options);
-  const llmConfig = createLLMConfig(options);
   // Get GitHub-specific tools and prompts
   const githubTools = await createGitHubTools(githubToken, toolsSubset);
   const prompts = await createGithubPrompts(character);
@@ -74,7 +72,6 @@ const createGithubAgentConfig = async (
     monitoringConfig,
     characterDataPathConfig,
     apiConfig,
-    llmConfig,
     stopCounterLimit,
   };
 };

--- a/core/src/agents/workflows/orchestrator/config.ts
+++ b/core/src/agents/workflows/orchestrator/config.ts
@@ -1,5 +1,5 @@
 import { Character } from '../../../config/types.js';
-import { LLMConfiguration, LLMFactoryConfig } from '../../../services/llm/types.js';
+import { LLMConfiguration } from '../../../services/llm/types.js';
 import { createLogger } from '../../../utils/logger.js';
 import { createPrompts } from './prompts.js';
 import { createDefaultOrchestratorTools } from './tools.js';
@@ -158,20 +158,6 @@ export const createApiConfig = (options?: OrchestratorRunnerOptions): ApiConfig 
   };
 };
 
-/**
- * Helper function to create an LLMConfig based on user options
- */
-export const createLLMConfig = (options?: OrchestratorRunnerOptions): LLMFactoryConfig => {
-  return {
-    OPENAI_API_KEY: options?.llmConfig?.OPENAI_API_KEY,
-    ANTHROPIC_API_KEY: options?.llmConfig?.ANTHROPIC_API_KEY,
-    LLAMA_API_URL: options?.llmConfig?.LLAMA_API_URL,
-    DEEPSEEK_API_KEY: options?.llmConfig?.DEEPSEEK_API_KEY,
-    DEEPSEEK_URL: options?.llmConfig?.DEEPSEEK_URL,
-    GROQ_API_KEY: options?.llmConfig?.GROQ_API_KEY,
-  };
-};
-
 export const createStopCounterLimit = (options?: OrchestratorRunnerOptions): number => {
   return options?.stopCounterLimit ?? 3;
 };
@@ -197,14 +183,12 @@ export const createOrchestratorConfig = async (
   const pruningParameters = createPruningParameters(options);
   const characterDataPathConfig = createCharacterDataPathConfig(options);
   const apiConfig = createApiConfig(options);
-  const llmConfig = createLLMConfig(options);
   const stopCounterLimit = createStopCounterLimit(options);
   // Get tools - merge custom tools with defaults if experience saving is enabled
   const tools: Tools = [
     ...(options?.tools || []),
     ...createDefaultOrchestratorTools(
       baseConfig.namespace,
-      llmConfig,
       characterDataPathConfig.dataPath,
       experienceConfig.saveExperiences ? experienceConfig.experienceManager : undefined,
     ),
@@ -225,7 +209,6 @@ export const createOrchestratorConfig = async (
     monitoringConfig,
     characterDataPathConfig,
     apiConfig,
-    llmConfig,
     stopCounterLimit,
   };
 };

--- a/core/src/agents/workflows/orchestrator/nodes.ts
+++ b/core/src/agents/workflows/orchestrator/nodes.ts
@@ -20,7 +20,6 @@ export const createNodes = async ({
   pruningParameters,
   namespace,
   apiConfig,
-  llmConfig,
   stopCounterLimit,
 }: OrchestratorConfig): Promise<OrchestratorNodes> => {
   const { inputPrompt, messageSummaryPrompt, finishWorkflowPrompt } = prompts;
@@ -33,7 +32,6 @@ export const createNodes = async ({
     tools,
     namespace,
     apiConfig,
-    llmConfig,
   });
   const messageSummaryNode = createMessageSummaryNode({
     modelConfig: messageSummaryModelConfig,
@@ -41,14 +39,12 @@ export const createNodes = async ({
     pruningParameters,
     namespace,
     apiConfig,
-    llmConfig,
   });
   const finishWorkflowNode = createFinishWorkflowNode({
     modelConfig: finishWorkflowModelConfig,
     finishWorkflowPrompt,
     namespace,
     apiConfig,
-    llmConfig,
   });
   const toolExecutionNode = createToolExecutionNode({
     tools: tools as DynamicStructuredTool[],

--- a/core/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
@@ -65,9 +65,7 @@ export const createFinishWorkflowNode = ({
         ? prepareAnthropicPrompt(formattedMessages, logger)
         : formattedMessages;
 
-    const result = await LLMFactory.createModelFromConfig(modelConfig).invoke(
-      promptToSend,
-    );
+    const result = await LLMFactory.createModelFromConfig(modelConfig).invoke(promptToSend);
     const finishedWorkflow = await parseFinishedWorkflow(result.content, logger);
 
     logger.info('Finished Workflow:', { finishedWorkflow });

--- a/core/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/finishWorkflowNode.ts
@@ -1,5 +1,5 @@
 import { ChatPromptTemplate } from '@langchain/core/prompts';
-import { LLMConfiguration, LLMFactoryConfig } from '../../../../services/llm/types.js';
+import { LLMConfiguration } from '../../../../services/llm/types.js';
 import { LLMFactory } from '../../../../services/llm/factory.js';
 import { createLogger } from '../../../../utils/logger.js';
 import { ApiConfig, OrchestratorStateType } from '../types.js';
@@ -30,13 +30,11 @@ export const createFinishWorkflowNode = ({
   finishWorkflowPrompt,
   namespace,
   apiConfig,
-  llmConfig,
 }: {
   modelConfig: LLMConfiguration;
   finishWorkflowPrompt: ChatPromptTemplate;
   namespace: string;
   apiConfig: ApiConfig;
-  llmConfig: LLMFactoryConfig;
 }) => {
   const logger = attachLogger(
     createLogger(`${namespace}-finish-workflow-node`),
@@ -67,7 +65,7 @@ export const createFinishWorkflowNode = ({
         ? prepareAnthropicPrompt(formattedMessages, logger)
         : formattedMessages;
 
-    const result = await LLMFactory.createModelFromConfig(modelConfig, llmConfig).invoke(
+    const result = await LLMFactory.createModelFromConfig(modelConfig).invoke(
       promptToSend,
     );
     const finishedWorkflow = await parseFinishedWorkflow(result.content, logger);

--- a/core/src/agents/workflows/orchestrator/nodes/inputNode.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/inputNode.ts
@@ -1,7 +1,7 @@
 import { LLMFactory } from '../../../../services/llm/factory.js';
 import { createLogger } from '../../../../utils/logger.js';
 import { ApiConfig, InputNodeFunction, OrchestratorStateType, Tools } from '../types.js';
-import { LLMConfiguration, LLMFactoryConfig } from '../../../../services/llm/types.js';
+import { LLMConfiguration } from '../../../../services/llm/types.js';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { attachLogger } from '../../../../api/server.js';
 import { prepareAnthropicPrompt } from './utils.js';
@@ -14,14 +14,12 @@ export const createInputNode = ({
   tools,
   namespace,
   apiConfig,
-  llmConfig,
 }: {
   modelConfig: LLMConfiguration;
   inputPrompt: ChatPromptTemplate;
   tools: Tools;
   namespace: string;
   apiConfig: ApiConfig;
-  llmConfig: LLMFactoryConfig;
 }): InputNodeFunction => {
   const logger = attachLogger(
     createLogger(`${namespace}-input-node`),
@@ -54,7 +52,7 @@ export const createInputNode = ({
         ? prepareAnthropicPrompt(formattedMessages, logger)
         : formattedMessages;
 
-    const result = await LLMFactory.createModel(modelConfig, llmConfig)
+    const result = await LLMFactory.createModel(modelConfig)
       .bindTools(toolsNewInterface)
       .invoke(promptToSend);
 

--- a/core/src/agents/workflows/orchestrator/nodes/messageSummaryNode.ts
+++ b/core/src/agents/workflows/orchestrator/nodes/messageSummaryNode.ts
@@ -2,7 +2,7 @@ import { AIMessage } from '@langchain/core/messages';
 import { createLogger } from '../../../../utils/logger.js';
 import { ApiConfig, OrchestratorStateType } from '../types.js';
 import { LLMFactory } from '../../../../services/llm/factory.js';
-import { LLMConfiguration, LLMFactoryConfig } from '../../../../services/llm/types.js';
+import { LLMConfiguration } from '../../../../services/llm/types.js';
 import { PruningParameters } from '../types.js';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { attachLogger } from '../../../../api/server.js';
@@ -14,14 +14,12 @@ export const createMessageSummaryNode = ({
   pruningParameters,
   namespace,
   apiConfig,
-  llmConfig,
 }: {
   modelConfig: LLMConfiguration;
   messageSummaryPrompt: ChatPromptTemplate;
   pruningParameters: PruningParameters;
   namespace: string;
   apiConfig: ApiConfig;
-  llmConfig: LLMFactoryConfig;
 }) => {
   const logger = attachLogger(
     createLogger(`${namespace}-message-summary-node`),
@@ -56,7 +54,7 @@ export const createMessageSummaryNode = ({
         ? prepareAnthropicPrompt(formattedMessages, logger)
         : formattedMessages;
 
-    const newSummary = await LLMFactory.createModel(modelConfig, llmConfig).invoke(promptToSend);
+    const newSummary = await LLMFactory.createModel(modelConfig).invoke(promptToSend);
     logger.info('New Summary Result:', { newSummary });
 
     const summaryContent =

--- a/core/src/agents/workflows/orchestrator/tools.ts
+++ b/core/src/agents/workflows/orchestrator/tools.ts
@@ -5,15 +5,13 @@ import { createGetCurrentTimeTool } from '../../tools/time/index.js';
 import { createStopWorkflowTool } from '../../tools/stopWorkflow/index.js';
 import { createThinkingTool } from '../../tools/thinking/index.js';
 import { workflowControlState } from './orchestratorWorkflow.js';
-import { LLMFactoryConfig } from '../../../services/llm/types.js';
 
 export const createDefaultOrchestratorTools = (
   namespace: string,
-  llmConfig: LLMFactoryConfig,
   dataPath: string,
   experienceManager?: ExperienceManager,
 ) => {
-  const experienceVectorDb = getVectorDB('experiences', llmConfig, dataPath);
+  const experienceVectorDb = getVectorDB('experiences', dataPath);
   const agentExperienceTools = createAgentExperienceTools(experienceVectorDb, experienceManager);
   const getCurrentTimeTool = createGetCurrentTimeTool();
   const stopWorkflowTool = createStopWorkflowTool(workflowControlState, namespace);

--- a/core/src/agents/workflows/orchestrator/types.ts
+++ b/core/src/agents/workflows/orchestrator/types.ts
@@ -4,7 +4,6 @@ import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { LLMConfiguration } from '../../../services/llm/types.js';
 import { Logger } from 'winston';
 import { ExperienceManager } from '../../../blockchain/agentExperience/types.js';
-import { LLMFactoryConfig } from '../../../services/llm/types.js';
 
 export type OrchestratorPrompts = {
   inputPrompt: ChatPromptTemplate;
@@ -76,7 +75,6 @@ export type OrchestratorRunnerOptions = {
   characterDataPathConfig?: CharacterDataPathConfig;
   recursionLimit?: number;
   apiConfig?: ApiConfig;
-  llmConfig?: LLMConfig;
   stopCounterLimit?: number;
   logger?: Logger;
 };
@@ -93,7 +91,6 @@ export type OrchestratorConfig = {
   characterDataPathConfig: CharacterDataPathConfig;
   recursionLimit: number;
   apiConfig: ApiConfig;
-  llmConfig: LLMFactoryConfig;
   stopCounterLimit: number;
   logger?: Logger;
 };

--- a/core/src/agents/workflows/slack/slackAgent.ts
+++ b/core/src/agents/workflows/slack/slackAgent.ts
@@ -13,7 +13,6 @@ import {
   createApiConfig,
   createCharacterDataPathConfig,
   createExperienceConfig,
-  createLLMConfig,
   createModelConfigurations,
   createMonitoringConfig,
   createPruningParameters,
@@ -53,7 +52,6 @@ const createSlackAgentConfig = async (
   const pruningParameters = createPruningParameters(options);
   const characterDataPathConfig = createCharacterDataPathConfig(options);
   const apiConfig = createApiConfig(options);
-  const llmConfig = createLLMConfig(options);
   // Get Slack-specific tools and prompts
   const slackTools = await createSlackTools(slackToken);
   const prompts = await createSlackPrompts(character);
@@ -73,7 +71,6 @@ const createSlackAgentConfig = async (
     monitoringConfig,
     characterDataPathConfig,
     apiConfig,
-    llmConfig,
     stopCounterLimit,
   };
 };

--- a/core/src/agents/workflows/twitter/twitterAgent.ts
+++ b/core/src/agents/workflows/twitter/twitterAgent.ts
@@ -15,7 +15,6 @@ import {
   createApiConfig,
   createCharacterDataPathConfig,
   createExperienceConfig,
-  createLLMConfig,
   createModelConfigurations,
   createMonitoringConfig,
   createPruningParameters,
@@ -65,7 +64,6 @@ const createTwitterAgentConfig = async (
   const pruningParameters = createPruningParameters(options);
   const characterDataPathConfig = createCharacterDataPathConfig(options);
   const apiConfig = createApiConfig(options);
-  const llmConfig = createLLMConfig(options);
   // Get Twitter-specific tools and prompts
   const twitterTools = createAllTwitterTools(
     twitterApi,
@@ -90,7 +88,6 @@ const createTwitterAgentConfig = async (
     monitoringConfig,
     characterDataPathConfig,
     apiConfig,
-    llmConfig,
     stopCounterLimit,
   };
 };

--- a/core/src/api/types.ts
+++ b/core/src/api/types.ts
@@ -2,7 +2,6 @@ import { Express } from 'express';
 import { Server } from 'http';
 import { Logger } from 'winston';
 import { Http2SecureServer } from 'http2';
-import { LLMFactoryConfig } from '../services/llm/types.js';
 import { ChatWorkflow } from '../agents/chat/types.js';
 export interface ApiServer {
   app: Express;
@@ -24,7 +23,6 @@ export type RestApiConfig = {
   authToken: string;
   apiPort: number;
   allowedOrigins: string[];
-  llmConfig: LLMFactoryConfig;
 };
 
 /// TODO - dataPath and llmConfig should be removed
@@ -35,6 +33,5 @@ export type CreateApiServerParams = {
   authToken: string;
   apiPort: number;
   allowedOrigins: string[];
-  llmConfig: LLMFactoryConfig;
   chatAppInstance?: ChatWorkflow;
 };

--- a/core/src/config/config.ts
+++ b/core/src/config/config.ts
@@ -138,7 +138,6 @@ export const getConfig = async (options?: ConfigOptions): Promise<ConfigInstance
 
       NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET || '',
 
-
       autoDriveConfig: {
         AUTO_DRIVE_API_KEY: process.env.AUTO_DRIVE_API_KEY,
         AUTO_DRIVE_ENCRYPTION_PASSWORD: process.env.AUTO_DRIVE_ENCRYPTION_PASSWORD,

--- a/core/src/config/config.ts
+++ b/core/src/config/config.ts
@@ -138,14 +138,6 @@ export const getConfig = async (options?: ConfigOptions): Promise<ConfigInstance
 
       NOTION_INTEGRATION_SECRET: process.env.NOTION_INTEGRATION_SECRET || '',
 
-      llmConfig: {
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
-        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || '',
-        LLAMA_API_URL: process.env.LLAMA_API_URL || '',
-        DEEPSEEK_URL: process.env.DEEPSEEK_URL || '',
-        DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY || '',
-        GROQ_API_KEY: process.env.GROQ_API_KEY || '',
-      },
 
       autoDriveConfig: {
         AUTO_DRIVE_API_KEY: process.env.AUTO_DRIVE_API_KEY,

--- a/core/src/config/schema.ts
+++ b/core/src/config/schema.ts
@@ -2,15 +2,6 @@ import { NetworkId } from '@autonomys/auto-utils';
 import { z } from 'zod';
 import { LLMConfiguration, LLMProvider } from '../services/llm/types.js';
 
-const llmConfigSchema = z.object({
-  OPENAI_API_KEY: z.string(),
-  ANTHROPIC_API_KEY: z.string(),
-  LLAMA_API_URL: z.string(),
-  DEEPSEEK_URL: z.string(),
-  DEEPSEEK_API_KEY: z.string(),
-  GROQ_API_KEY: z.string(),
-});
-
 const llmProviderSchema: z.ZodType<LLMProvider> = z.enum([
   'openai',
   'anthropic',
@@ -145,7 +136,6 @@ const apiSecurityConfigSchema = z.object({
 
 export const configSchema = z.object({
   twitterConfig: twitterConfigSchema,
-  llmConfig: llmConfigSchema,
   autoDriveConfig: autoDriveConfigSchema,
   blockchainConfig: blockchainConfigSchema,
   memoryConfig: memoryConfigSchema,

--- a/core/src/services/llm/factory.ts
+++ b/core/src/services/llm/factory.ts
@@ -1,22 +1,19 @@
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatOllama } from '@langchain/ollama';
-import { LLMConfiguration, LLMFactoryConfig } from './types.js';
+import { LLMConfiguration } from './types.js';
 import { ChatGroq } from '@langchain/groq';
-
+import { ChatDeepSeek } from '@langchain/deepseek';
 export class LLMFactory {
-  static createModel(node: LLMConfiguration, config: LLMFactoryConfig) {
-    return this.createModelFromConfig(node, config);
+  static createModel(node: LLMConfiguration) {
+    return this.createModelFromConfig(node);
   }
 
   static createModelFromConfig(
-    { model, provider, temperature }: LLMConfiguration,
-    config: LLMFactoryConfig,
-  ) {
+    { model, provider, temperature }: LLMConfiguration ) {
     switch (provider) {
       case 'openai':
         const baseConfig = {
-          apiKey: config.OPENAI_API_KEY,
           model,
         };
         if (!model.includes('o3-mini') && !model.includes('o4-mini')) {
@@ -28,7 +25,6 @@ export class LLMFactory {
         return new ChatOpenAI(baseConfig);
       case 'anthropic':
         return new ChatAnthropic({
-          apiKey: config.ANTHROPIC_API_KEY,
           model,
           temperature,
           clientOptions: {
@@ -39,22 +35,17 @@ export class LLMFactory {
         });
       case 'ollama':
         return new ChatOllama({
-          baseUrl: config.LLAMA_API_URL,
+          baseUrl: process.env.OLLAMA_API_URL,
           model,
           temperature,
         });
       case 'deepseek':
-        return new ChatOpenAI({
-          apiKey: config.DEEPSEEK_API_KEY,
-          configuration: {
-            baseURL: config.DEEPSEEK_URL,
-          },
+        return new ChatDeepSeek({
           model,
           temperature,
         });
       case 'groq':
         return new ChatGroq({
-          apiKey: config.GROQ_API_KEY,
           model,
           temperature,
         });

--- a/core/src/services/llm/factory.ts
+++ b/core/src/services/llm/factory.ts
@@ -9,9 +9,7 @@ export class LLMFactory {
     return this.createModelFromConfig(node);
   }
 
-  static createModelFromConfig(
-    { model, provider, temperature }: LLMConfiguration,
-  ) {
+  static createModelFromConfig({ model, provider, temperature }: LLMConfiguration) {
     switch (provider) {
       case 'openai':
         if (!process.env.OPENAI_API_KEY) {

--- a/core/src/services/llm/factory.ts
+++ b/core/src/services/llm/factory.ts
@@ -10,9 +10,13 @@ export class LLMFactory {
   }
 
   static createModelFromConfig(
-    { model, provider, temperature }: LLMConfiguration ) {
+    { model, provider, temperature }: LLMConfiguration,
+  ) {
     switch (provider) {
       case 'openai':
+        if (!process.env.OPENAI_API_KEY) {
+          throw new Error('OPENAI_API_KEY is not set');
+        }
         const baseConfig = {
           model,
         };
@@ -24,6 +28,9 @@ export class LLMFactory {
         }
         return new ChatOpenAI(baseConfig);
       case 'anthropic':
+        if (!process.env.ANTHROPIC_API_KEY) {
+          throw new Error('ANTHROPIC_API_KEY is not set');
+        }
         return new ChatAnthropic({
           model,
           temperature,
@@ -34,17 +41,26 @@ export class LLMFactory {
           },
         });
       case 'ollama':
+        if (!process.env.OLLAMA_API_URL) {
+          throw new Error('OLLAMA_API_URL is not set');
+        }
         return new ChatOllama({
           baseUrl: process.env.OLLAMA_API_URL,
           model,
           temperature,
         });
       case 'deepseek':
+        if (!process.env.DEEPSEEK_API_KEY) {
+          throw new Error('DEEPSEEK_API_KEY is not set');
+        }
         return new ChatDeepSeek({
           model,
           temperature,
         });
       case 'groq':
+        if (!process.env.GROQ_API_KEY) {
+          throw new Error('GROQ_API_KEY is not set');
+        }
         return new ChatGroq({
           model,
           temperature,

--- a/core/src/services/llm/types.ts
+++ b/core/src/services/llm/types.ts
@@ -1,14 +1,5 @@
 export type LLMProvider = 'openai' | 'anthropic' | 'ollama' | 'deepseek' | 'groq';
 
-export interface LLMFactoryConfig {
-  OPENAI_API_KEY?: string;
-  ANTHROPIC_API_KEY?: string;
-  LLAMA_API_URL?: string;
-  DEEPSEEK_API_KEY?: string;
-  DEEPSEEK_URL?: string;
-  GROQ_API_KEY?: string;
-}
-
 export type LLMConfiguration = {
   provider: LLMProvider;
   model: string;

--- a/core/src/services/vectorDb/VectorDB.ts
+++ b/core/src/services/vectorDb/VectorDB.ts
@@ -4,7 +4,6 @@ import { OpenAI } from 'openai/index.mjs';
 import { createLogger } from '../../utils/logger.js';
 import { join } from 'path';
 import { existsSync, mkdirSync } from 'fs';
-import { LLMFactoryConfig } from '../llm/types.js';
 const logger = createLogger('vector-database');
 
 export class VectorDB {
@@ -17,7 +16,6 @@ export class VectorDB {
 
   constructor(
     namespace: string,
-    llmConfig: LLMFactoryConfig,
     dataPath: string,
     maxElements?: number,
   ) {
@@ -31,7 +29,7 @@ export class VectorDB {
     this.dbFilePath = join(targetDir, `${namespace}-store.db`);
     this.maxElements = maxElements ?? VectorDB.DEFAULT_MAX_ELEMENTS;
     this.openai = new OpenAI({
-      apiKey: llmConfig.OPENAI_API_KEY,
+      apiKey: process.env.OPENAI_API_KEY,
     });
 
     this.initializeDatabase();

--- a/core/src/services/vectorDb/VectorDB.ts
+++ b/core/src/services/vectorDb/VectorDB.ts
@@ -14,11 +14,7 @@ export class VectorDB {
   private maxElements: number;
   private static readonly DEFAULT_MAX_ELEMENTS = 100000;
 
-  constructor(
-    namespace: string,
-    dataPath: string,
-    maxElements?: number,
-  ) {
+  constructor(namespace: string, dataPath: string, maxElements?: number) {
     const targetDir = join(dataPath, 'data', namespace);
 
     if (!existsSync(targetDir)) {

--- a/core/src/services/vectorDb/vectorDBPool.ts
+++ b/core/src/services/vectorDb/vectorDBPool.ts
@@ -1,6 +1,5 @@
 import { VectorDB } from './VectorDB.js';
 import { createLogger } from '../../utils/logger.js';
-import { LLMFactoryConfig } from '../llm/types.js';
 
 const logger = createLogger('vector-database-pool');
 
@@ -15,13 +14,12 @@ const dbInstances: Map<string, VectorDB> = new Map();
  */
 export const getVectorDB = (
   namespace: string,
-  llmConfig: LLMFactoryConfig,
   dataPath: string,
   maxElements?: number,
 ): VectorDB => {
   if (!dbInstances.has(namespace)) {
     logger.info(`Creating new VectorDB instance for namespace: ${namespace}`);
-    const db = new VectorDB(namespace, llmConfig, dataPath, maxElements);
+    const db = new VectorDB(namespace, dataPath, maxElements);
     dbInstances.set(namespace, db);
   }
   const db = dbInstances.get(namespace);

--- a/examples/twitterAgent/index.ts
+++ b/examples/twitterAgent/index.ts
@@ -37,11 +37,8 @@ const chatAppInstance = async (): Promise<any> => {
     provider: 'openai',
     temperature: 0.5,
   };
-  const llmConfig = {
-    OPENAI_API_KEY: config.llmConfig.OPENAI_API_KEY,
-  };
-  const tools = createDefaultChatTools(llmConfig, config.characterConfig.characterPath);
-  const chatNodeConfig = createChatNodeConfig({ modelConfig, tools, llmConfig });
+  const tools = createDefaultChatTools(config.characterConfig.characterPath);
+  const chatNodeConfig = createChatNodeConfig({ modelConfig, tools });
   const chatAppInstance = createChatWorkflow(chatNodeConfig);
   return chatAppInstance;
 }
@@ -100,7 +97,7 @@ const orchestratorConfig = async (): Promise<OrchestratorRunnerOptions> => {
       : {
         enabled: false as const,
       };
-
+  
   //Twitter agent config
   const twitterAgentTool =
     config.twitterConfig.USERNAME && config.twitterConfig.PASSWORD
@@ -190,7 +187,6 @@ createApiServer({
   authToken: config.apiSecurityConfig.API_TOKEN ?? '',
   apiPort: config.API_PORT,
   allowedOrigins: config.apiSecurityConfig.CORS_ALLOWED_ORIGINS,
-  llmConfig: config.llmConfig,
   chatAppInstance: await chatAppInstance(),
 });
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "example": "yarn workspace autonomys-agents-examples tsx index.ts"
   },
   "dependencies": {
+    "@langchain/core": "^0.3.53",
+    "@langchain/deepseek": "^0.0.1",
     "@types/yargs": "^17.0.33",
     "better-sqlite3": "^11.8.0",
     "yargs": "^17.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3929,6 +3929,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@langchain/core@npm:^0.3.53":
+  version: 0.3.53
+  resolution: "@langchain/core@npm:0.3.53"
+  dependencies:
+    "@cfworker/json-schema": "npm:^4.0.2"
+    ansi-styles: "npm:^5.0.0"
+    camelcase: "npm:6"
+    decamelize: "npm:1.2.0"
+    js-tiktoken: "npm:^1.0.12"
+    langsmith: "npm:^0.3.16"
+    mustache: "npm:^4.2.0"
+    p-queue: "npm:^6.6.2"
+    p-retry: "npm:4"
+    uuid: "npm:^10.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.22.3"
+  checksum: 10c0/006e2ef11354d85dc9cd3529f8ec747bbe8e7e8bdf57bff8a0949155e04186563848f0047469f406702d3c69d1d9acb776a95303ee94183227dbebcd75383fbd
+  languageName: node
+  linkType: hard
+
+"@langchain/deepseek@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@langchain/deepseek@npm:0.0.1"
+  dependencies:
+    "@langchain/openai": "npm:^0.4.2"
+    zod: "npm:^3.24.1"
+  peerDependencies:
+    "@langchain/core": ">=0.3.0 <0.4.0"
+  checksum: 10c0/d4412a1e380ccc12f35169fde6541484f14ba08bb317d44d103fab3592f26e25b8c24c8d0553d30b1a90cd43f82a565623221211a77f0ac892d076df25984f4d
+  languageName: node
+  linkType: hard
+
 "@langchain/groq@npm:0.2.0":
   version: 0.2.0
   resolution: "@langchain/groq@npm:0.2.0"
@@ -4048,6 +4080,20 @@ __metadata:
   peerDependencies:
     "@langchain/core": ">=0.3.29 <0.4.0"
   checksum: 10c0/42a7013c331361008b1989692ef515521e145dcd599612c3d687734c9dfd82109adb7eb428f69b0ce0e45c2bdc2d288ddb4094b25d6d29c84d2450e7da19a2b4
+  languageName: node
+  linkType: hard
+
+"@langchain/openai@npm:^0.4.2":
+  version: 0.4.9
+  resolution: "@langchain/openai@npm:0.4.9"
+  dependencies:
+    js-tiktoken: "npm:^1.0.12"
+    openai: "npm:^4.87.3"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.22.3"
+  peerDependencies:
+    "@langchain/core": ">=0.3.39 <0.4.0"
+  checksum: 10c0/456db6d039fad521caf9c2dab547075120d1156282c9eb891430b83f34d617121f4d97fda2be7954558910ddac8d235effe6071a002b93e60f460111318466d2
   languageName: node
   linkType: hard
 
@@ -8674,6 +8720,8 @@ __metadata:
   resolution: "autonomys-agents@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.18.0"
+    "@langchain/core": "npm:^0.3.53"
+    "@langchain/deepseek": "npm:^0.0.1"
     "@types/better-sqlite3": "npm:^7.6.12"
     "@types/yargs": "npm:^17.0.33"
     "@typescript-eslint/eslint-plugin": "npm:^8.29.0"


### PR DESCRIPTION
This PR continues the implementation of the chat workflow system started in Part 1 (PR #416), focusing on LLM configuration simplification and environment variable standardization.
Langchain has built-in functions to load the credentials if they are available as environment variables in runtime. Since we load all the credentials from the character env file, it is unnecessary to have llmConfig.

## Overview

This is the **second part** of our planned PR series for the chat workflow implementation. This PR focuses on:
1. Simplifying the LLM configuration across the codebase
2. Standardizing environment variable names
3. Removing redundant configuration passing

## Key Changes

- Removed `llmConfig` parameter from workflow configurations
  - Previously, LLM API keys were passed through multiple layers unnecessarily
  - Now LLM configuration is handled directly by the LLMFactory
- Renamed `LLAMA_API_URL` to `OLLAMA_API_URL` for better clarity
- Simplified the Vector DB initialization by removing redundant config passing
- Updated all corresponding node implementations to use the simplified approach

## Technical Details

- Removed `createLLMConfig` helper function from orchestrator workflow
- Updated all node implementations to use the simplified LLM creation pattern:
  - Before: `LLMFactory.createModel(modelConfig, llmConfig)`
  - After: `LLMFactory.createModel(modelConfig)`
- Updated various agent implementations:
  - GitHub Agent
  - Slack Agent
  - Orchestrator

## Benefits

- **Simplified Configuration**: Reduced parameter passing and configuration complexity
- **Standardized API**: More consistent approach to LLM creation
- **Better Maintainability**: Less redundant code and configuration
- **Clearer Naming**: Environment variable names now match their actual purpose

## Related Changes

- Updated example environment variables for consistency
- Ensured backward compatibility with existing agent implementations