### PR TITLE
remove `/api` extension from web-cli docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A modern web-based interface for interacting with your agent. To start:
 3. **Update Web CLI Environment**  
    Edit the `.env` file with your configuration:
    - `PORT`: The port for running the Web CLI interface
-   - `REACT_APP_API_BASE_URL`: Your Agent API address (e.g., http://localhost:3010/api)
+   - `REACT_APP_API_BASE_URL`: Your Agent API address (e.g., http://localhost:3010)
    - `REACT_APP_API_TOKEN`: The same token used in your agent configuration
 
 4. **Start the Web Interface**
@@ -115,7 +115,7 @@ You can have web cli as a container by runnint the command below
 docker run -d \
       -p <HOST_LOCAL_PORT>:<CONTAINER_PORT> \
       -e PORT=<CONTAINER_PORT> \
-      -e RUNTIME_API_URL="<YOUR_API_URL>" \ # example: https://localhost:3010/api
+      -e RUNTIME_API_URL="<YOUR_API_URL>" \
       -e RUNTIME_API_TOKEN="<YOUR_API_TOKEN>" \
       --name autonomys-web-cli \
       ghcr.io/autonomys/autonomys-agents/web-cli:latest

--- a/docker/web-cli/docker-compose.yml
+++ b/docker/web-cli/docker-compose.yml
@@ -8,5 +8,5 @@ services:
       - "${PORT:-3000}:${PORT:-3000}"
     environment:
       PORT: ${PORT:-3000}
-      RUNTIME_API_URL: ${RUNTIME_API_URL:-https://localhost:3000/api}
+      RUNTIME_API_URL: ${RUNTIME_API_URL:-https://localhost:3000}
       RUNTIME_API_TOKEN: ${RUNTIME_API_TOKEN:-}

--- a/docker/web-cli/entrypoint.sh
+++ b/docker/web-cli/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Define defaults if runtime variables aren't set
-export RUNTIME_API_URL=${RUNTIME_API_URL:-http://localhost:3010/api}
+export RUNTIME_API_URL=${RUNTIME_API_URL:-http://localhost:3010}
 # Use :- which defaults to empty string if RUNTIME_API_TOKEN is unset or null
 export RUNTIME_API_TOKEN=${RUNTIME_API_TOKEN:-}
 export PORT=${PORT:-3000}


### PR DESCRIPTION
These changes are necessary following PR #419 