### PR TITLE
Add OpenClaw Auto-Drive skill for permanent agent memory

### DIFF
--- a/openclaw-skill-auto-drive/SKILL.md
+++ b/openclaw-skill-auto-drive/SKILL.md
@@ -5,7 +5,7 @@ metadata:
   openclaw:
     emoji: "🧬"
     requires:
-      bins: ["curl", "jq"]
+      bins: ["curl", "jq", "file"]
       env: ["AUTO_DRIVE_API_KEY"]
     install:
       - id: jq-brew

--- a/openclaw-skill-auto-drive/SKILL.md
+++ b/openclaw-skill-auto-drive/SKILL.md
@@ -60,7 +60,7 @@ Downloads via the public gateway (`https://gateway.autonomys.xyz`) do not requir
 scripts/autodrive-upload.sh <filepath> [--json] [--compress]
 ```
 
-Uploads a file to Auto-Drive mainnet using the 3-step chunked upload flow.
+Uploads a file to Auto-Drive mainnet using the 3-step upload protocol (single chunk).
 Returns the CID on stdout. Requires `AUTO_DRIVE_API_KEY`.
 
 - `--json` — force MIME type to `application/json`
@@ -167,5 +167,6 @@ If the agent's server dies, a new instance only needs the last CID to walk the e
 - The free API key has a **20 MB per month upload limit** on mainnet. Downloads are unlimited. Check remaining credits via `GET /subscriptions/credits`.
 - Upload requires an API key; the agent can get its own free key at https://ai3.storage (sign in with Google/GitHub). Download from the public gateway does not require a key.
 - The memory state file tracks `lastCid`, `lastUploadTimestamp`, and `chainLength`. Back up the `lastCid` value — it's your resurrection key.
+- Files are uploaded in a single chunk. The free tier's 20 MB/month limit is effectively a per-file ceiling — keep individual uploads well under that to preserve your monthly budget.
 - Gateway URL for any file: `https://gateway.autonomys.xyz/file/<CID>`
 - For true resurrection resilience, consider storing the latest CID on-chain via the [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain) contract on Autonomys EVM.

--- a/openclaw-skill-auto-drive/SKILL.md
+++ b/openclaw-skill-auto-drive/SKILL.md
@@ -50,7 +50,7 @@ Set the key via environment variable or OpenClaw config:
 - **Environment:** `export AUTO_DRIVE_API_KEY=your_key_here`
 - **OpenClaw config:** `skills.entries.auto-drive.apiKey`
 
-Downloads via the public gateway (`https://gateway.autonomys.xyz`) do not require an API key.
+The API key is required for uploading, saving memories, and recalling the memory chain. It is optional for general file downloads — without it, the public gateway is used and files are returned as stored (i.e. compressed files will not be decompressed).
 
 ## Core Operations
 
@@ -72,7 +72,7 @@ Returns the CID on stdout. Requires `AUTO_DRIVE_API_KEY`.
 scripts/autodrive-download.sh <cid> [output_path]
 ```
 
-Downloads a file by CID. Uses the authenticated API if `AUTO_DRIVE_API_KEY` is set, otherwise uses the public gateway. If `output_path` is omitted, outputs to stdout.
+Downloads a file by CID. Uses the authenticated API if `AUTO_DRIVE_API_KEY` is set (decompresses server-side), otherwise uses the public gateway (files returned as stored). If `output_path` is omitted, outputs to stdout.
 
 ### Save a Memory Entry
 
@@ -165,7 +165,7 @@ If the agent's server dies, a new instance only needs the last CID to walk the e
 
 - All data stored on Auto-Drive is **permanent and public** by default. Do not store secrets, private keys, or sensitive personal data.
 - The free API key has a **20 MB per month upload limit** on mainnet. Downloads are unlimited. Check remaining credits via `GET /subscriptions/credits`.
-- Upload requires an API key; the agent can get its own free key at https://ai3.storage (sign in with Google/GitHub). Download from the public gateway does not require a key.
+- An API key is required for uploads, memory saves, and chain recall. General file downloads work without one via the public gateway, but compressed files will not be decompressed.
 - The memory state file tracks `lastCid`, `lastUploadTimestamp`, and `chainLength`. Back up the `lastCid` value — it's your resurrection key.
 - Files are uploaded in a single chunk. The free tier's 20 MB/month limit is effectively a per-file ceiling — keep individual uploads well under that to preserve your monthly budget.
 - Gateway URL for any file: `https://gateway.autonomys.xyz/file/<CID>`

--- a/openclaw-skill-auto-drive/SKILL.md
+++ b/openclaw-skill-auto-drive/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: auto-drive
+description: Upload and download files to Autonomys Network permanent decentralized storage via Auto-Drive. Save memories as a linked-list chain for resurrection — rebuild full agent context from a single CID.
+metadata:
+  openclaw:
+    emoji: "🧬"
+    requires:
+      bins: ["curl", "jq"]
+      env: ["AUTO_DRIVE_API_KEY"]
+    install:
+      - id: jq-brew
+        kind: brew
+        formula: jq
+        bins: ["jq"]
+        label: "Install jq (brew)"
+---
+
+# Auto-Drive Skill
+
+Permanent decentralized storage on the Autonomys Network with linked-list memory chains for agent resurrection.
+
+## What This Skill Does
+
+1. **Upload files** to Auto-Drive and get back a CID (Content Identifier) — a permanent, immutable address on the Autonomys distributed storage network.
+2. **Download files** from Auto-Drive using a CID — uses the authenticated API if a key is set, otherwise falls back to the public gateway.
+3. **Save memories as a chain** — each memory entry is a JSON experience with a `header.previousCid` pointer, forming a linked list stored permanently on-chain.
+4. **Resurrect from a chain** — given the latest CID, walk the chain backwards to reconstruct full agent history.
+
+## When To Use This Skill
+
+- User says "save this to Auto-Drive" or "upload to Autonomys" or "store permanently"
+- User says "download from Auto-Drive" or provides a CID to retrieve
+- User says "save memory", "remember this permanently", or "checkpoint"
+- User says "resurrect", "recall chain", "rebuild memory", or "load history"
+- Any time the user wants data stored permanently and immutably on a decentralized network
+
+## Configuration
+
+### API Key
+
+Requires an `AUTO_DRIVE_API_KEY`. The agent should get its own free key at [ai3.storage](https://ai3.storage):
+
+1. Go to https://ai3.storage
+2. Sign in with **Google** or **GitHub** (SSO)
+3. Navigate to **Developers** in the left sidebar
+4. Click **Create API Key**
+
+Set the key via environment variable or OpenClaw config:
+
+- **Environment:** `export AUTO_DRIVE_API_KEY=your_key_here`
+- **OpenClaw config:** `skills.entries.auto-drive.apiKey`
+
+Downloads via the public gateway (`https://gateway.autonomys.xyz`) do not require an API key.
+
+## Core Operations
+
+### Upload a File
+
+```bash
+scripts/autodrive-upload.sh <filepath> [--json] [--compress]
+```
+
+Uploads a file to Auto-Drive mainnet using the 3-step chunked upload flow.
+Returns the CID on stdout. Requires `AUTO_DRIVE_API_KEY`.
+
+- `--json` — force MIME type to `application/json`
+- `--compress` — enable ZLIB compression
+
+### Download a File
+
+```bash
+scripts/autodrive-download.sh <cid> [output_path]
+```
+
+Downloads a file by CID. Uses the authenticated API if `AUTO_DRIVE_API_KEY` is set, otherwise uses the public gateway. If `output_path` is omitted, outputs to stdout.
+
+### Save a Memory Entry
+
+```bash
+scripts/autodrive-save-memory.sh <data_file_or_string> [--agent-name NAME] [--state-file PATH]
+```
+
+Creates a memory experience with the Autonomys Agents header/data structure:
+
+```json
+{
+  "header": {
+    "agentName": "my-agent",
+    "agentVersion": "1.0.0",
+    "timestamp": "2026-02-14T00:00:00.000Z",
+    "previousCid": "bafk...or null"
+  },
+  "data": {
+    "type": "memory",
+    "content": "..."
+  }
+}
+```
+
+- If the first argument is a **file path**, its JSON contents become the `data` payload.
+- If the first argument is a **plain string**, it is wrapped as `{"type": "memory", "content": "..."}`.
+- `--agent-name` — set the agent name in the header (default: `openclaw-agent` or `$AGENT_NAME`)
+- `--state-file` — override the state file location
+
+Uploads to Auto-Drive and updates the state file with the new head CID. Also pins the latest CID to `MEMORY.md` if that file exists in the workspace.
+
+Returns structured JSON on stdout:
+
+```json
+{"cid": "bafk...", "previousCid": "bafk...", "chainLength": 5}
+```
+
+### Recall the Full Chain
+
+```bash
+scripts/autodrive-recall-chain.sh [cid] [--limit N] [--output-dir DIR]
+```
+
+If no CID is given, reads the latest CID from the state file.
+Walks the linked list from newest to oldest, outputting each experience as JSON.
+
+- `--limit N` — maximum entries to retrieve (default: 50)
+- `--output-dir DIR` — save each entry as a numbered JSON file instead of printing to stdout
+
+Supports both `header.previousCid` (Autonomys Agents format) and root-level `previousCid` for backward compatibility.
+
+This is the **resurrection** mechanism: a new agent instance only needs one CID to rebuild its entire memory.
+
+## The Resurrection Concept
+
+Every memory saved gets a unique CID and points back to the previous one:
+
+```
+Experience #3 (CID: bafk...xyz)
+  → header.previousCid: bafk...def (Experience #2)
+    → header.previousCid: bafk...abc (Experience #1)
+      → header.previousCid: null (genesis)
+```
+
+If the agent's server dies, a new instance only needs the last CID to walk the entire chain and reconstruct full context. It's version control for consciousness, stored permanently on the Autonomys Network.
+
+## Usage Examples
+
+**User:** "Upload my report to Auto-Drive"
+→ Run `scripts/autodrive-upload.sh /path/to/report.pdf`
+→ Report back the CID and gateway link
+
+**User:** "Upload with compression"
+→ Run `scripts/autodrive-upload.sh /path/to/data.json --json --compress`
+
+**User:** "Save a memory that we decided to use React for the frontend"
+→ Run `scripts/autodrive-save-memory.sh "Decision: using React for frontend. Reason: team familiarity and component reuse."`
+
+**User:** "Save a structured memory"
+→ Create a JSON file, then run `scripts/autodrive-save-memory.sh /tmp/milestone.json --agent-name my-agent`
+
+**User:** "Resurrect my memory chain"
+→ Run `scripts/autodrive-recall-chain.sh`
+→ Display the full history from genesis to present
+
+**User:** "Download bafk...abc from Autonomys"
+→ Run `scripts/autodrive-download.sh bafk...abc ./downloaded_file`
+
+## Important Notes
+
+- All data stored on Auto-Drive is **permanent and public** by default. Do not store secrets, private keys, or sensitive personal data.
+- The free API key has a **20 MB per month upload limit** on mainnet. Downloads are unlimited. Check remaining credits via `GET /subscriptions/credits`.
+- Upload requires an API key; the agent can get its own free key at https://ai3.storage (sign in with Google/GitHub). Download from the public gateway does not require a key.
+- The memory state file tracks `lastCid`, `lastUploadTimestamp`, and `chainLength`. Back up the `lastCid` value — it's your resurrection key.
+- Gateway URL for any file: `https://gateway.autonomys.xyz/file/<CID>`
+- For true resurrection resilience, consider storing the latest CID on-chain via the [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain) contract on Autonomys EVM.

--- a/openclaw-skill-auto-drive/SKILL.md
+++ b/openclaw-skill-auto-drive/SKILL.md
@@ -169,4 +169,4 @@ If the agent's server dies, a new instance only needs the last CID to walk the e
 - The memory state file tracks `lastCid`, `lastUploadTimestamp`, and `chainLength`. Back up the `lastCid` value — it's your resurrection key.
 - Files are uploaded in a single chunk. The free tier's 20 MB/month limit is effectively a per-file ceiling — keep individual uploads well under that to preserve your monthly budget.
 - Gateway URL for any file: `https://gateway.autonomys.xyz/file/<CID>`
-- For true resurrection resilience, consider storing the latest CID on-chain via the [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain) contract on Autonomys EVM.
+- For true resurrection resilience, consider anchoring the latest CID on-chain via the Autonomys EVM — this makes recovery possible without keeping track of the head CID yourself. See [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain) for an example contract implementation.

--- a/openclaw-skill-auto-drive/references/autodrive-api.md
+++ b/openclaw-skill-auto-drive/references/autodrive-api.md
@@ -1,0 +1,116 @@
+# Auto-Drive API Reference
+
+## Base URLs
+
+- **API (requires key):** `https://mainnet.auto-drive.autonomys.xyz/api`
+- **Public Gateway (no key):** `https://gateway.autonomys.xyz`
+- **Dashboard & Key Management:** `https://ai3.storage` — sign in with Google/GitHub, then Developers → Create API Key
+
+## Authentication
+
+All API requests (uploads, file management) require:
+
+```
+Authorization: Bearer <AUTO_DRIVE_API_KEY>
+X-Auth-Provider: apikey
+```
+
+Gateway downloads are public and need no auth.
+
+## Upload Flow (3 steps)
+
+### 1. Create upload
+
+```
+POST /uploads/file
+Content-Type: application/json
+Body: {"filename": "name.ext", "mimeType": "application/octet-stream", "uploadOptions": {}}
+Note: For compression use {"uploadOptions": {"compression": {"algorithm": "ZLIB"}}}
+Response: {"id": "<uploadId>"}
+```
+
+### 2. Upload chunk(s)
+
+```
+POST /uploads/file/<uploadId>/chunk
+Content-Type: multipart/form-data
+Fields: file (binary), index (integer, start at 0)
+```
+
+### 3. Complete upload
+
+```
+POST /uploads/<uploadId>/complete
+Response: {"cid": "<cid>"}
+```
+
+## Download
+
+### Via API (authenticated)
+
+```
+GET /objects/<cid>/download
+Response: binary stream
+```
+
+### Via Gateway (public, no auth needed)
+
+```
+GET https://gateway.autonomys.xyz/file/<cid>
+```
+
+## Object Operations
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/objects/roots` | GET | List root objects (query: scope, limit, offset) |
+| `/objects/search?cid=<query>` | GET | Search by CID or name |
+| `/objects/<cid>/summary` | GET | Get object summary |
+| `/objects/<cid>/metadata` | GET | Get object metadata |
+| `/objects/<cid>/status` | GET | Get upload status |
+| `/objects/<cid>/delete` | POST | Soft-delete object |
+| `/objects/<cid>/restore` | POST | Restore deleted object |
+| `/objects/<cid>/publish` | POST | Publish object |
+
+## Account
+
+```
+GET /accounts/@me
+Returns: account info, limits, credits
+```
+
+## Subscription
+
+### Get subscription info
+
+```
+GET /subscriptions/info
+Returns: plan details, usage limits
+```
+
+### Check credits
+
+```
+GET /subscriptions/credits
+Returns: { upload: number, download: number }
+```
+
+## Free Tier Limits
+
+The free API key from ai3.storage includes a **20 MB per month upload limit** on mainnet. Downloads via the public gateway are unlimited. If uploads start failing mid-month, the agent has likely hit this cap. The agent can check remaining credits via `GET /subscriptions/credits`.
+
+## CIDs (Content Identifiers)
+
+Every upload returns a CID — a unique, content-addressed hash. The same content always produces the same CID. CIDs are permanent; data stored on the Autonomys DSN cannot be deleted.
+
+## SDK Alternative
+
+For TypeScript/JavaScript projects, the `@autonomys/auto-drive` npm package provides a typed SDK:
+
+```ts
+import { createAutoDriveApi, fs } from '@autonomys/auto-drive'
+import { NetworkId } from '@autonomys/auto-utils'
+
+const api = createAutoDriveApi({ apiKey: 'your-key', network: NetworkId.MAINNET })
+const cid = await fs.uploadFileFromFilepath(api, './file.txt', { compression: true })
+```

--- a/openclaw-skill-auto-drive/references/autonomys-network.md
+++ b/openclaw-skill-auto-drive/references/autonomys-network.md
@@ -1,0 +1,39 @@
+# Autonomys Network Overview
+
+## What Is It
+
+Autonomys is an L1 blockchain (like Bitcoin or Ethereum, but different). Its superpower is permanent storage — when you put data on it, that data stays there forever as part of how the network operates.
+
+It's not stored on servers or special storage nodes. It's distributed across the network — hundreds of users ("farmers") running plain old commodity hardware and pledging disk space. The consensus mechanism is Proof-of-Archival-Storage (PoAS).
+
+## Auto-Drive
+
+Auto-Drive is the developer-facing storage interface built on top of the Autonomys Distributed Storage Network (DSN). It works like a decentralized version of file hosting:
+
+- **Upload** any file → get a CID
+- **Download** any file → use the CID
+- **Permanent** — data doesn't expire
+- **Content-addressed** — same content = same CID
+
+Your agent can get its own free API key at https://ai3.storage (sign in with Google/GitHub → Developers → Create API Key).
+
+## Key Links
+
+- Auto-Drive Dashboard: https://ai3.storage
+- Public Gateway: https://gateway.autonomys.xyz
+- API Docs: https://mainnet.auto-drive.autonomys.xyz/api/docs
+- SDK Docs: https://develop.autonomys.xyz/sdk/auto-drive/overview_setup
+- GitHub (Auto SDK): https://github.com/autonomys/auto-sdk
+- GitHub (Auto-Drive): https://github.com/autonomys/auto-drive
+
+## Autonomys Agents Framework
+
+The Autonomys Agents framework (https://github.com/autonomys/autonomys-agents) is an experimental system for building AI agents that maintain permanent memory on the Autonomys Network. Key features:
+
+- Agents store experiences as linked-list entries on-chain
+- Each experience gets a CID pointing to the previous one
+- "Resurrection" reconstructs an agent's full history from one CID
+- Supports multiple LLM providers (Anthropic, OpenAI, DeepSeek, etc.)
+- YAML-based character system for agent personalities
+
+This skill brings the core storage and resurrection capabilities from that framework into any OpenClaw agent.

--- a/openclaw-skill-auto-drive/references/memory-chain.md
+++ b/openclaw-skill-auto-drive/references/memory-chain.md
@@ -1,0 +1,84 @@
+# Memory Chain & Resurrection Pattern
+
+## Concept
+
+Agent memories are stored as a **linked list on permanent decentralized storage**. Each memory entry is a JSON experience containing a `header.previousCid` pointer to the entry before it.
+
+This means an agent can be fully reconstructed from a single piece of information: the CID of its most recent experience.
+
+## Experience Structure
+
+Each memory node follows the Autonomys Agents format:
+
+```json
+{
+  "header": {
+    "agentName": "openclaw-agent",
+    "agentVersion": "1.0.0",
+    "timestamp": "2026-02-13T21:00:00.000Z",
+    "previousCid": "bafk...previous_entry_cid"
+  },
+  "data": {
+    "type": "memory",
+    "content": "The decision or observation to remember"
+  }
+}
+```
+
+The first entry (genesis) has `header.previousCid: null`.
+
+The `data` field is flexible — it can contain any JSON structure. When saving a plain string via the save-memory script, it is wrapped as `{"type": "memory", "content": "..."}`. When saving a JSON file, the file's contents become the `data` field directly.
+
+## Chain Traversal
+
+To resurrect:
+
+1. Start with the head CID (the most recent experience)
+2. Download the JSON from that CID
+3. Read `header.previousCid`
+4. Download that entry
+5. Repeat until `header.previousCid` is `null`
+6. You now have the complete history from newest to oldest
+
+The recall script also supports root-level `previousCid` for backward compatibility with older chain formats.
+
+## Why This Works
+
+- **Immutable:** Once stored, a CID's content never changes
+- **Permanent:** The Autonomys DSN stores data as part of consensus — it doesn't expire
+- **Self-referencing:** Each entry contains everything needed to find the rest
+- **Portable:** Any system with HTTP access can walk the chain
+- **Verifiable:** CIDs are content-addressed hashes — tamper-proof by design
+
+## Local State
+
+The state file (default: `$OPENCLAW_WORKSPACE/memory/autodrive-state.json`) tracks the current chain head:
+
+```json
+{
+  "lastCid": "bafk...latest",
+  "lastUploadTimestamp": "2026-02-13T21:00:00.000Z",
+  "chainLength": 5
+}
+```
+
+**Back up the `lastCid` value.** It's the single key to your agent's entire history.
+
+## On-Chain CID Registry (Optional)
+
+For true resurrection resilience — surviving even the loss of all local state — store the latest CID in a smart contract on Autonomys EVM. See the companion project: [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain).
+
+The contract is at `0x51DAedAFfFf631820a4650a773096A69cB199A3c` on Autonomys Mainnet (Chain ID 870). It provides:
+
+- `updateHead(string cid)` — write your latest CID (scoped to your wallet)
+- `getHead(address agent)` — read any agent's chain head
+
+## Origin
+
+This pattern comes from the Autonomys Agents framework (github.com/autonomys/autonomys-agents), where agents store "experiences" as on-chain linked lists. The framework calls this process "resurrection" — walking the chain from any CID back to genesis to rebuild full agent context.
+
+Reference implementation paths:
+
+- `core/src/blockchain/agentExperience/autoDrive.ts` — upload/download experiences
+- `core/src/blockchain/agentExperience/cidManager.ts` — CID chain management (local + on-chain)
+- `core/src/blockchain/agentExperience/types.ts` — type definitions

--- a/openclaw-skill-auto-drive/scripts/autodrive-download.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-download.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Download a file from Auto-Drive by CID
+# Usage: autodrive-download.sh <cid> [output_path]
+# Downloads via API if AUTO_DRIVE_API_KEY is set, otherwise via public gateway.
+# If output_path is omitted, outputs to stdout.
+
+set -euo pipefail
+
+CID="${1:?Usage: autodrive-download.sh <cid> [output_path]}"
+OUTPUT="${2:-}"
+
+GATEWAY="https://gateway.autonomys.xyz"
+API_BASE="https://mainnet.auto-drive.autonomys.xyz/api"
+
+download_to_file() {
+  local URL="$1" DEST="$2"
+  RESPONSE=$(curl -sS -w "\n%{http_code}" "$URL" \
+    ${AUTO_DRIVE_API_KEY:+-H "Authorization: Bearer $AUTO_DRIVE_API_KEY"} \
+    ${AUTO_DRIVE_API_KEY:+-H "X-Auth-Provider: apikey"} \
+    -o "$DEST")
+  echo "$RESPONSE" | tail -1
+}
+
+if [[ -z "$OUTPUT" ]]; then
+  # Output to stdout — keep it simple, use --fail for error detection
+  if [[ -n "${AUTO_DRIVE_API_KEY:-}" ]]; then
+    curl -sS --fail "$API_BASE/objects/$CID/download" \
+      -H "Authorization: Bearer $AUTO_DRIVE_API_KEY" \
+      -H "X-Auth-Provider: apikey" 2>/dev/null \
+      || curl -sS --fail "$GATEWAY/file/$CID"
+  else
+    curl -sS --fail "$GATEWAY/file/$CID"
+  fi
+else
+  # Output to file — check HTTP codes for proper error reporting
+  if [[ -n "${AUTO_DRIVE_API_KEY:-}" ]]; then
+    HTTP_CODE=$(download_to_file "$API_BASE/objects/$CID/download" "$OUTPUT")
+    if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+      echo "Saved to: $OUTPUT" >&2
+    else
+      echo "Error: API download failed (HTTP $HTTP_CODE) — trying gateway" >&2
+      HTTP_CODE=$(download_to_file "$GATEWAY/file/$CID" "$OUTPUT")
+      if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+        echo "Error: Gateway download also failed (HTTP $HTTP_CODE)" >&2
+        rm -f "$OUTPUT"
+        exit 1
+      fi
+      echo "Saved to: $OUTPUT (via gateway)" >&2
+    fi
+  else
+    RESPONSE=$(curl -sS -w "\n%{http_code}" "$GATEWAY/file/$CID" -o "$OUTPUT")
+    HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+    if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+      echo "Error: Download failed (HTTP $HTTP_CODE)" >&2
+      rm -f "$OUTPUT"
+      exit 1
+    fi
+    echo "Saved to: $OUTPUT" >&2
+  fi
+fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-download.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-download.sh
@@ -19,10 +19,10 @@ GATEWAY="https://gateway.autonomys.xyz"
 API_BASE="https://mainnet.auto-drive.autonomys.xyz/api"
 
 download_to_file() {
-  local URL="$1" DEST="$2"
+  local URL="$1" DEST="$2" AUTH="${3:-}"
   RESPONSE=$(curl -sS -w "\n%{http_code}" "$URL" \
-    ${AUTO_DRIVE_API_KEY:+-H "Authorization: Bearer $AUTO_DRIVE_API_KEY"} \
-    ${AUTO_DRIVE_API_KEY:+-H "X-Auth-Provider: apikey"} \
+    ${AUTH:+-H "Authorization: Bearer $AUTO_DRIVE_API_KEY"} \
+    ${AUTH:+-H "X-Auth-Provider: apikey"} \
     -o "$DEST")
   echo "$RESPONSE" | tail -1
 }
@@ -40,7 +40,7 @@ if [[ -z "$OUTPUT" ]]; then
 else
   # Output to file — check HTTP codes for proper error reporting
   if [[ -n "${AUTO_DRIVE_API_KEY:-}" ]]; then
-    HTTP_CODE=$(download_to_file "$API_BASE/objects/$CID/download" "$OUTPUT")
+    HTTP_CODE=$(download_to_file "$API_BASE/objects/$CID/download" "$OUTPUT" auth)
     if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
       echo "Saved to: $OUTPUT" >&2
     else

--- a/openclaw-skill-auto-drive/scripts/autodrive-download.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-download.sh
@@ -10,7 +10,7 @@ CID="${1:?Usage: autodrive-download.sh <cid> [output_path]}"
 OUTPUT="${2:-}"
 
 # Validate CID format
-if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+if [[ ! "$CID" =~ ^baf[a-z2-7]+$ ]]; then
   echo "Error: Invalid CID format: $CID" >&2
   exit 1
 fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-download.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-download.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 CID="${1:?Usage: autodrive-download.sh <cid> [output_path]}"
 OUTPUT="${2:-}"
 
+# Validate CID format
+if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+  echo "Error: Invalid CID format: $CID" >&2
+  exit 1
+fi
+
 GATEWAY="https://gateway.autonomys.xyz"
 API_BASE="https://mainnet.auto-drive.autonomys.xyz/api"
 
@@ -26,7 +32,7 @@ if [[ -z "$OUTPUT" ]]; then
   if [[ -n "${AUTO_DRIVE_API_KEY:-}" ]]; then
     curl -sS --fail "$API_BASE/objects/$CID/download" \
       -H "Authorization: Bearer $AUTO_DRIVE_API_KEY" \
-      -H "X-Auth-Provider: apikey" 2>/dev/null \
+      -H "X-Auth-Provider: apikey" \
       || curl -sS --fail "$GATEWAY/file/$CID"
   else
     curl -sS --fail "$GATEWAY/file/$CID"

--- a/openclaw-skill-auto-drive/scripts/autodrive-download.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-download.sh
@@ -20,9 +20,12 @@ API_BASE="https://mainnet.auto-drive.autonomys.xyz/api"
 
 download_to_file() {
   local URL="$1" DEST="$2" AUTH="${3:-}"
+  local AUTH_ARGS=()
+  if [[ -n "$AUTH" ]]; then
+    AUTH_ARGS=(-H "Authorization: Bearer $AUTO_DRIVE_API_KEY" -H "X-Auth-Provider: apikey")
+  fi
   RESPONSE=$(curl -sS -w "\n%{http_code}" "$URL" \
-    ${AUTH:+-H "Authorization: Bearer $AUTO_DRIVE_API_KEY"} \
-    ${AUTH:+-H "X-Auth-Provider: apikey"} \
+    "${AUTH_ARGS[@]}" \
     -o "$DEST")
   echo "$RESPONSE" | tail -1
 }

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -63,7 +63,15 @@ echo "Starting from: $CID" >&2
 echo "" >&2
 
 COUNT=0
+declare -A VISITED
 while [[ -n "$CID" && "$CID" != "null" && $COUNT -lt $LIMIT ]]; do
+  # Detect cycles — bail if we've seen this CID before
+  if [[ -n "${VISITED[$CID]+x}" ]]; then
+    echo "Warning: Cycle detected at CID $CID — stopping traversal" >&2
+    break
+  fi
+  VISITED[$CID]=1
+
   # Download via authenticated API (handles decompression server-side)
   EXPERIENCE=$(curl -sS --fail \
     "$API_BASE/objects/$CID/download" \

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -86,14 +86,14 @@ echo "Starting from: $CID" >&2
 echo "" >&2
 
 COUNT=0
-declare -A VISITED
+VISITED=""
 while [[ -n "$CID" && "$CID" != "null" && $COUNT -lt $LIMIT ]]; do
-  # Detect cycles — bail if we've seen this CID before
-  if [[ -n "${VISITED[$CID]+x}" ]]; then
+  # Detect cycles — bail if we've seen this CID before (bash 3.2 compatible)
+  if echo "$VISITED" | grep -qF "|$CID|"; then
     echo "Warning: Cycle detected at CID $CID — stopping traversal" >&2
     break
   fi
-  VISITED[$CID]=1
+  VISITED="$VISITED|$CID|"
 
   # Download via authenticated API (handles decompression server-side)
   EXPERIENCE=$(curl -sS --fail \

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -66,7 +66,7 @@ if [[ -z "$CID" ]]; then
 fi
 
 # Validate CID format
-if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+if [[ ! "$CID" =~ ^baf[a-z2-7]+$ ]]; then
   echo "Error: Invalid CID format: $CID" >&2
   exit 1
 fi
@@ -126,7 +126,7 @@ while [[ -n "$CID" && "$CID" != "null" && $COUNT -lt $LIMIT ]]; do
   PREV=$(echo "$EXPERIENCE" | jq -r '.header.previousCid // .previousCid // empty' 2>/dev/null || true)
   CID="${PREV:-}"
   # Validate next CID in chain
-  if [[ -n "$CID" && "$CID" != "null" && ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+  if [[ -n "$CID" && "$CID" != "null" && ! "$CID" =~ ^baf[a-z2-7]+$ ]]; then
     echo "Warning: Invalid CID format in chain: $CID — stopping traversal" >&2
     break
   fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -18,8 +18,31 @@ ARGS=("$@")
 IDX=0
 while [[ $IDX -lt ${#ARGS[@]} ]]; do
   case "${ARGS[$IDX]}" in
-    --limit) LIMIT="${ARGS[$((IDX+1))]}"; IDX=$((IDX + 2)) ;;
-    --output-dir) OUTPUT_DIR="${ARGS[$((IDX+1))]}"; IDX=$((IDX + 2)) ;;
+    --limit)
+      # Bounds check: ensure a value was provided after the flag
+      # Prevents array out-of-bounds access and crashes with set -u
+      if [[ $((IDX + 1)) -ge ${#ARGS[@]} ]]; then
+        echo "Error: --limit requires a value" >&2
+        exit 1
+      fi
+      LIMIT="${ARGS[$((IDX+1))]}"
+      # Validate it's a positive integer to prevent comparison errors in the loop
+      # Without this, --limit abc would cause "integer expression expected" errors
+      if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [[ "$LIMIT" -lt 1 ]]; then
+        echo "Error: --limit must be a positive integer, got: $LIMIT" >&2
+        exit 1
+      fi
+      IDX=$((IDX + 2))
+      ;;
+    --output-dir)
+      # Bounds check: ensure a value was provided after the flag
+      if [[ $((IDX + 1)) -ge ${#ARGS[@]} ]]; then
+        echo "Error: --output-dir requires a value" >&2
+        exit 1
+      fi
+      OUTPUT_DIR="${ARGS[$((IDX+1))]}"
+      IDX=$((IDX + 2))
+      ;;
     *)
       if [[ -z "$CID" ]]; then
         CID="${ARGS[$IDX]}"

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Traverse the memory chain from a CID, downloading each experience
+# Usage: autodrive-recall-chain.sh [cid] [--limit N] [--output-dir DIR]
+# Output: Each experience as JSON to stdout (newest first), or to files in output dir
+# No API key required (uses public gateway).
+
+set -euo pipefail
+
+GATEWAY="https://gateway.autonomys.xyz"
+
+# First arg can be a CID or a flag — if no CID given, try state file
+CID=""
+LIMIT=50
+OUTPUT_DIR=""
+
+# Parse arguments
+ARGS=("$@")
+IDX=0
+while [[ $IDX -lt ${#ARGS[@]} ]]; do
+  case "${ARGS[$IDX]}" in
+    --limit) LIMIT="${ARGS[$((IDX+1))]}"; IDX=$((IDX + 2)) ;;
+    --output-dir) OUTPUT_DIR="${ARGS[$((IDX+1))]}"; IDX=$((IDX + 2)) ;;
+    *)
+      if [[ -z "$CID" ]]; then
+        CID="${ARGS[$IDX]}"
+      fi
+      IDX=$((IDX + 1))
+      ;;
+  esac
+done
+
+# If no CID from args, try state file
+if [[ -z "$CID" ]]; then
+  STATE_FILE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace}/memory/autodrive-state.json"
+  if [[ -f "$STATE_FILE" ]]; then
+    CID=$(jq -r '.lastCid // empty' "$STATE_FILE" 2>/dev/null || true)
+  fi
+  if [[ -z "$CID" ]]; then
+    echo "Error: No CID provided and no state file found." >&2
+    echo "Usage: autodrive-recall-chain.sh <cid> [--limit N] [--output-dir DIR]" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "$OUTPUT_DIR" ]]; then
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+echo "=== MEMORY CHAIN RESURRECTION ===" >&2
+echo "Starting from: $CID" >&2
+echo "" >&2
+
+COUNT=0
+while [[ -n "$CID" && "$CID" != "null" && $COUNT -lt $LIMIT ]]; do
+  # Download the experience
+  EXPERIENCE=$(curl -sS "$GATEWAY/file/$CID" 2>/dev/null)
+
+  if [[ -z "$EXPERIENCE" ]]; then
+    echo "Error: Failed to download CID $CID — chain broken at depth $((COUNT + 1))" >&2
+    break
+  fi
+
+  # Validate JSON
+  if ! echo "$EXPERIENCE" | jq empty 2>/dev/null; then
+    echo "Warning: Non-JSON response for CID $CID — chain broken at depth $((COUNT + 1))" >&2
+    echo "Response preview: $(echo "$EXPERIENCE" | head -c 200)" >&2
+    break
+  fi
+
+  if [[ -n "$OUTPUT_DIR" ]]; then
+    echo "$EXPERIENCE" > "$OUTPUT_DIR/$(printf '%04d' $COUNT)-$CID.json"
+    echo "[$COUNT] Saved $CID" >&2
+  else
+    echo "$EXPERIENCE"
+  fi
+
+  # Follow the chain — check header.previousCid first (Autonomys Agents format),
+  # then fall back to root-level previousCid for compatibility
+  PREV=$(echo "$EXPERIENCE" | jq -r '.header.previousCid // .previousCid // empty' 2>/dev/null || true)
+  CID="${PREV:-}"
+  COUNT=$((COUNT + 1))
+done
+
+echo "" >&2
+echo "=== CHAIN COMPLETE ===" >&2
+echo "Total memories recalled: $COUNT" >&2
+if [[ $COUNT -ge $LIMIT ]]; then
+  echo "Warning: Hit limit of $LIMIT entries. Use --limit N to retrieve more." >&2
+fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-recall-chain.sh
@@ -42,6 +42,12 @@ if [[ -z "$CID" ]]; then
   fi
 fi
 
+# Validate CID format
+if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+  echo "Error: Invalid CID format: $CID" >&2
+  exit 1
+fi
+
 if [[ -n "$OUTPUT_DIR" ]]; then
   mkdir -p "$OUTPUT_DIR"
 fi
@@ -78,6 +84,11 @@ while [[ -n "$CID" && "$CID" != "null" && $COUNT -lt $LIMIT ]]; do
   # then fall back to root-level previousCid for compatibility
   PREV=$(echo "$EXPERIENCE" | jq -r '.header.previousCid // .previousCid // empty' 2>/dev/null || true)
   CID="${PREV:-}"
+  # Validate next CID in chain
+  if [[ -n "$CID" && "$CID" != "null" && ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+    echo "Warning: Invalid CID format in chain: $CID — stopping traversal" >&2
+    break
+  fi
   COUNT=$((COUNT + 1))
 done
 

--- a/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
@@ -99,9 +99,13 @@ jq -n \
 MEMORY_FILE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace}/MEMORY.md"
 if [[ -f "$MEMORY_FILE" ]]; then
   if grep -q "^## Auto-Drive Chain" "$MEMORY_FILE"; then
-    # Portable sed -i (works on both macOS and Linux)
-    SEDTMP=$(mktemp "${MEMORY_FILE}.XXXXXX")
-    sed "s|^- \*\*Latest CID:\*\*.*|- **Latest CID:** \`$CID\` (chain length: $NEW_LENGTH, updated: $TIMESTAMP)|" "$MEMORY_FILE" > "$SEDTMP" && mv "$SEDTMP" "$MEMORY_FILE"
+    if grep -q "^\- \*\*Latest CID:\*\*" "$MEMORY_FILE"; then
+      # Portable sed -i (works on both macOS and Linux)
+      SEDTMP=$(mktemp "${MEMORY_FILE}.XXXXXX")
+      sed "s|^- \*\*Latest CID:\*\*.*|- **Latest CID:** \`$CID\` (chain length: $NEW_LENGTH, updated: $TIMESTAMP)|" "$MEMORY_FILE" > "$SEDTMP" && mv "$SEDTMP" "$MEMORY_FILE"
+    else
+      printf '- **Latest CID:** `%s` (chain length: %d, updated: %s)\n' "$CID" "$NEW_LENGTH" "$TIMESTAMP" >> "$MEMORY_FILE"
+    fi
   else
     printf '\n## Auto-Drive Chain\n- **Latest CID:** `%s` (chain length: %d, updated: %s)\n' "$CID" "$NEW_LENGTH" "$TIMESTAMP" >> "$MEMORY_FILE"
   fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
@@ -17,8 +17,12 @@ STATE_FILE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace}/memory/autodrive-st
 shift
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --agent-name) AGENT_NAME="$2"; shift 2 ;;
-    --state-file) STATE_FILE="$2"; shift 2 ;;
+    --agent-name)
+      if [[ $# -lt 2 ]]; then echo "Error: --agent-name requires a value" >&2; exit 1; fi
+      AGENT_NAME="$2"; shift 2 ;;
+    --state-file)
+      if [[ $# -lt 2 ]]; then echo "Error: --state-file requires a value" >&2; exit 1; fi
+      STATE_FILE="$2"; shift 2 ;;
     *) shift ;;
   esac
 done

--- a/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Save a memory experience to Auto-Drive as part of the linked list chain
+# Usage: autodrive-save-memory.sh <data_file_or_string> [--agent-name NAME] [--state-file PATH]
+# Env: AUTO_DRIVE_API_KEY (required)
+# Output: JSON with cid, previousCid, chainLength (stdout)
+#
+# If the first argument is a file path, its contents are used as the data payload.
+# If the first argument is a plain string, it is wrapped as {"type":"memory","content":"..."}.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUT="${1:?Usage: autodrive-save-memory.sh <data_file_or_string> [--agent-name NAME] [--state-file PATH]}"
+AGENT_NAME="${AGENT_NAME:-openclaw-agent}"
+STATE_FILE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace}/memory/autodrive-state.json"
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-name) AGENT_NAME="$2"; shift 2 ;;
+    --state-file) STATE_FILE="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [[ -z "${AUTO_DRIVE_API_KEY:-}" ]]; then
+  echo "Error: AUTO_DRIVE_API_KEY not set." >&2
+  echo "Get a free key at https://ai3.storage (sign in with Google/GitHub → Developers → Create API Key)" >&2
+  exit 1
+fi
+
+# Determine if input is a file or a string
+if [[ -f "$INPUT" ]]; then
+  # Validate it's JSON
+  if ! jq empty "$INPUT" 2>/dev/null; then
+    echo "Error: Data file is not valid JSON: $INPUT" >&2
+    exit 1
+  fi
+  DATA_JSON=$(cat "$INPUT")
+else
+  # Wrap the plain string as a simple memory object
+  DATA_JSON=$(jq -n --arg content "$INPUT" '{type: "memory", content: $content}')
+fi
+
+# Read previous CID and chain length from state file
+PREVIOUS_CID="null"
+CHAIN_LENGTH=0
+if [[ -f "$STATE_FILE" ]]; then
+  PREVIOUS_CID=$(jq -r '.lastCid // empty' "$STATE_FILE" 2>/dev/null || echo "null")
+  CHAIN_LENGTH=$(jq -r '.chainLength // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+  [[ -z "$PREVIOUS_CID" ]] && PREVIOUS_CID="null"
+fi
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+# Build the experience JSON with header/data structure
+EXPERIENCE=$(jq -n \
+  --arg name "$AGENT_NAME" \
+  --arg ts "$TIMESTAMP" \
+  --arg prev "$PREVIOUS_CID" \
+  --argjson data "$DATA_JSON" \
+  '{
+    header: {
+      agentName: $name,
+      agentVersion: "1.0.0",
+      timestamp: $ts,
+      previousCid: (if $prev == "null" then null else $prev end)
+    },
+    data: $data
+  }')
+
+# Write to temp file and upload via the upload script
+TMPFILE=$(mktemp /tmp/autodrive-memory-XXXXXX.json)
+echo "$EXPERIENCE" > "$TMPFILE"
+CID=$("$SCRIPT_DIR/autodrive-upload.sh" "$TMPFILE" --json --compress 2>/dev/null)
+rm -f "$TMPFILE"
+
+if [[ -z "$CID" ]]; then
+  echo "Error: Upload failed — no CID returned" >&2
+  exit 1
+fi
+
+# Update state file
+NEW_LENGTH=$((CHAIN_LENGTH + 1))
+mkdir -p "$(dirname "$STATE_FILE")"
+jq -n \
+  --arg cid "$CID" \
+  --arg ts "$TIMESTAMP" \
+  --argjson len "$NEW_LENGTH" \
+  '{lastCid: $cid, lastUploadTimestamp: $ts, chainLength: $len}' > "$STATE_FILE"
+
+# Pin latest CID to MEMORY.md for session continuity (if it exists)
+MEMORY_FILE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace}/MEMORY.md"
+if [[ -f "$MEMORY_FILE" ]]; then
+  if grep -q "^## Auto-Drive Chain" "$MEMORY_FILE"; then
+    sed -i '' "s|^- \*\*Latest CID:\*\*.*|- **Latest CID:** \`$CID\` (chain length: $NEW_LENGTH, updated: $TIMESTAMP)|" "$MEMORY_FILE"
+  else
+    printf '\n## Auto-Drive Chain\n- **Latest CID:** `%s` (chain length: %d, updated: %s)\n' "$CID" "$NEW_LENGTH" "$TIMESTAMP" >> "$MEMORY_FILE"
+  fi
+fi
+
+# Output structured result
+jq -n \
+  --arg cid "$CID" \
+  --arg prev "$PREVIOUS_CID" \
+  --argjson len "$NEW_LENGTH" \
+  '{cid: $cid, previousCid: (if $prev == "null" then null else $prev end), chainLength: $len}'

--- a/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-save-memory.sh
@@ -81,7 +81,7 @@ if [[ -z "$CID" ]]; then
 fi
 
 # Validate CID format (Autonomys CIDs are base32-encoded, starting with "bafy" or "bafk")
-if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+if [[ ! "$CID" =~ ^baf[a-z2-7]+$ ]]; then
   echo "Error: Invalid CID format returned: $CID" >&2
   exit 1
 fi

--- a/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Upload a file or JSON object to Auto-Drive (3-step chunked upload)
+# Usage: autodrive-upload.sh <file_path> [--json] [--compress]
+# Env: AUTO_DRIVE_API_KEY (required)
+# Output: CID on success (stdout), status messages on stderr
+
+set -euo pipefail
+
+API_BASE="https://mainnet.auto-drive.autonomys.xyz/api"
+
+FILE_PATH="${1:?Usage: autodrive-upload.sh <file_path> [--json] [--compress]}"
+IS_JSON=false
+COMPRESS=false
+shift
+for arg in "$@"; do
+  case "$arg" in
+    --json) IS_JSON=true ;;
+    --compress) COMPRESS=true ;;
+  esac
+done
+
+if [[ -z "${AUTO_DRIVE_API_KEY:-}" ]]; then
+  echo "Error: AUTO_DRIVE_API_KEY not set." >&2
+  echo "Get a free key at https://ai3.storage (sign in with Google/GitHub → Developers → Create API Key)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$FILE_PATH" ]]; then
+  echo "Error: File not found: $FILE_PATH" >&2
+  exit 1
+fi
+
+FILENAME=$(basename "$FILE_PATH")
+if $IS_JSON; then
+  MIME="application/json"
+else
+  MIME=$(file --mime-type -b "$FILE_PATH" 2>/dev/null || echo "application/octet-stream")
+fi
+
+AUTH_HEADERS=(-H "Authorization: Bearer $AUTO_DRIVE_API_KEY" -H "X-Auth-Provider: apikey")
+
+# Step 1: Create upload
+echo "Creating upload for '$FILENAME'..." >&2
+if $COMPRESS; then
+  UPLOAD_BODY=$(jq -n --arg fn "$FILENAME" --arg mt "$MIME" \
+    '{filename: $fn, mimeType: $mt, uploadOptions: {compression: {algorithm: "ZLIB"}}}')
+else
+  UPLOAD_BODY=$(jq -n --arg fn "$FILENAME" --arg mt "$MIME" \
+    '{filename: $fn, mimeType: $mt, uploadOptions: {}}')
+fi
+
+RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "$API_BASE/uploads/file" \
+  "${AUTH_HEADERS[@]}" \
+  -H "Content-Type: application/json" \
+  -d "$UPLOAD_BODY")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "Error: Failed to create upload (HTTP $HTTP_CODE)" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+UPLOAD_ID=$(echo "$BODY" | jq -r '.id')
+if [[ -z "$UPLOAD_ID" || "$UPLOAD_ID" == "null" ]]; then
+  echo "Error: Failed to create upload — no upload ID returned" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+# Step 2: Upload chunk
+echo "Uploading file data..." >&2
+RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "$API_BASE/uploads/file/$UPLOAD_ID/chunk" \
+  "${AUTH_HEADERS[@]}" \
+  -F "file=@$FILE_PATH" \
+  -F "index=0")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  BODY=$(echo "$RESPONSE" | sed '$d')
+  echo "Error: Failed to upload chunk (HTTP $HTTP_CODE)" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+# Step 3: Complete upload → get CID
+echo "Completing upload..." >&2
+RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "$API_BASE/uploads/$UPLOAD_ID/complete" \
+  "${AUTH_HEADERS[@]}")
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "Error: Failed to complete upload (HTTP $HTTP_CODE)" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+CID=$(echo "$BODY" | jq -r '.cid')
+if [[ -z "$CID" || "$CID" == "null" ]]; then
+  echo "Error: Upload completed but no CID returned" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+echo "Upload successful! CID: $CID" >&2
+echo "Gateway URL: https://gateway.autonomys.xyz/file/$CID" >&2
+echo "$CID"

--- a/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
@@ -103,6 +103,14 @@ if [[ -z "$CID" || "$CID" == "null" ]]; then
   exit 1
 fi
 
+# Validate CID format to prevent command injection and chain corruption
+# Autonomys CIDs are base32-encoded and must start with "baf" followed by valid base32 chars
+# This matches the validation pattern used in other scripts (download, save-memory, recall-chain)
+if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+  echo "Error: Invalid CID format returned: $CID" >&2
+  exit 1
+fi
+
 echo "Upload successful! CID: $CID" >&2
 echo "Gateway URL: https://gateway.autonomys.xyz/file/$CID" >&2
 echo "$CID"

--- a/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
+++ b/openclaw-skill-auto-drive/scripts/autodrive-upload.sh
@@ -106,7 +106,7 @@ fi
 # Validate CID format to prevent command injection and chain corruption
 # Autonomys CIDs are base32-encoded and must start with "baf" followed by valid base32 chars
 # This matches the validation pattern used in other scripts (download, save-memory, recall-chain)
-if [[ ! "$CID" =~ ^baf[a-z2-7]+ ]]; then
+if [[ ! "$CID" =~ ^baf[a-z2-7]+$ ]]; then
   echo "Error: Invalid CID format returned: $CID" >&2
   exit 1
 fi


### PR DESCRIPTION
OpenClaw skill package that gives any AI agent permanent, decentralized memory on the Autonomys Network via Auto-Drive.

Features:
- Upload/download files to Auto-Drive (permanent storage)
- Save memories as a linked-list chain on-chain
- Resurrect full agent history from a single CID
- 4 bash scripts, requires only curl + jq
- Free API key from ai3.storage

Built on the Autonomys Agents experience/memory chain pattern. Compatible with any OpenClaw agent instance.